### PR TITLE
fix(google): sort resolved variants when fetching font css

### DIFF
--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -76,8 +76,7 @@ async function getFontDetails (family: string, variants: ResolveFontFacesOptions
   const weights = variableWeight
     ? [`${variableWeight.min}..${variableWeight.max}`]
     : variants.weights.filter(weight => String(weight) in font.fonts)
-  const resolvedVariants = weights.flatMap(w => [...styles].map(s => `${s},${w}`))
-  resolvedVariants.sort()
+  const resolvedVariants = weights.flatMap(w => [...styles].map(s => `${s},${w}`)).sort()
   let css = ''
 
   for (const extension in userAgents) {

--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -77,7 +77,7 @@ async function getFontDetails (family: string, variants: ResolveFontFacesOptions
     ? [`${variableWeight.min}..${variableWeight.max}`]
     : variants.weights.filter(weight => String(weight) in font.fonts)
   const resolvedVariants = weights.flatMap(w => [...styles].map(s => `${s},${w}`))
-
+  resolvedVariants.sort()
   let css = ''
 
   for (const extension in userAgents) {

--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -77,6 +77,7 @@ async function getFontDetails (family: string, variants: ResolveFontFacesOptions
     ? [`${variableWeight.min}..${variableWeight.max}`]
     : variants.weights.filter(weight => String(weight) in font.fonts)
   const resolvedVariants = weights.flatMap(w => [...styles].map(s => `${s},${w}`)).sort()
+
   let css = ''
 
   for (const extension in userAgents) {


### PR DESCRIPTION
Just a very simple fix to sort the variables list for Google Fonts. This fixes #32.