### PR TITLE
feat: warn when font weights are not available

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -182,10 +182,13 @@ export default defineNuxtModule<ModuleOptions>({
         if (provider.resolveFontFaces) {
           const result = await provider.resolveFontFaces(fontFamily, defaults)
           if (result) {
-            return {
-              fallbacks: result.fallbacks || defaults.fallbacks,
-              // Rewrite font source URLs to be proxied/local URLs
-              fonts: normalizeFontData(result.fonts),
+            const fonts = normalizeFontData(result.fonts)
+            if (fonts.length > 0) {
+              return {
+                fallbacks: result.fallbacks || defaults.fallbacks,
+                // Rewrite font source URLs to be proxied/local URLs
+                fonts,
+              }
             }
           }
         }

--- a/src/module.ts
+++ b/src/module.ts
@@ -163,7 +163,8 @@ export default defineNuxtModule<ModuleOptions>({
       if (override?.provider) {
         if (override.provider in providers) {
           const result = await providers[override.provider]!.resolveFontFaces!(fontFamily, defaults)
-          if (!result) {
+          const fonts = normalizeFontData(result?.fonts || [])
+          if (!fonts.length || !result) {
             return logger.warn(`Could not produce font face declaration from \`${override.provider}\` for font family \`${fontFamily}\`.`)
           }
           return {
@@ -189,6 +190,9 @@ export default defineNuxtModule<ModuleOptions>({
                 fallbacks: result.fallbacks || defaults.fallbacks,
                 fonts,
               }
+            }
+            if (override) {
+              logger.warn(`Could not produce font face declaration for \`${fontFamily}\` with override.`)
             }
           }
         }

--- a/src/module.ts
+++ b/src/module.ts
@@ -182,11 +182,11 @@ export default defineNuxtModule<ModuleOptions>({
         if (provider.resolveFontFaces) {
           const result = await provider.resolveFontFaces(fontFamily, defaults)
           if (result) {
+            // Rewrite font source URLs to be proxied/local URLs
             const fonts = normalizeFontData(result.fonts)
             if (fonts.length > 0) {
               return {
                 fallbacks: result.fallbacks || defaults.fallbacks,
-                // Rewrite font source URLs to be proxied/local URLs
                 fonts,
               }
             }

--- a/src/providers/bunny.ts
+++ b/src/providers/bunny.ts
@@ -65,16 +65,14 @@ async function getFontDetails (family: string, variants: ResolveFontFacesOptions
   const id = familyMap.get(family) as keyof typeof fonts
   const font = fonts[id]!
   const weights = variants.weights.filter(weight => font.weights.includes(Number(weight)))
-  if (weights.length == 0)
-    throw "No available font weights."
-  else if (variants.weights.length !== weights.length)
-    logger.warn(`Font weights \`${variants.weights}\` are not entirely available for \`${family}\` from \`bunny\`.`)
   const styleMap = {
     italic: 'i',
     oblique: 'i',
     normal: ''
   }
   const styles = new Set(variants.styles.map(i => styleMap[i]))
+  if (weights.length === 0 || styles.size === 0) return []
+
   const resolvedVariants = weights.flatMap(w => [...styles].map(s => `${w}${s}`))
 
   const css = await fontAPI('/css', {

--- a/src/providers/bunny.ts
+++ b/src/providers/bunny.ts
@@ -65,6 +65,10 @@ async function getFontDetails (family: string, variants: ResolveFontFacesOptions
   const id = familyMap.get(family) as keyof typeof fonts
   const font = fonts[id]!
   const weights = variants.weights.filter(weight => font.weights.includes(Number(weight)))
+  if (weights.length == 0)
+    throw "No available font weights."
+  else if (variants.weights.length !== weights.length)
+    logger.warn(`Font weights \`${variants.weights}\` are not entirely available for \`${family}\` from \`bunny\`.`)
   const styleMap = {
     italic: 'i',
     oblique: 'i',

--- a/src/providers/fontshare.ts
+++ b/src/providers/fontshare.ts
@@ -103,7 +103,8 @@ async function getFontDetails (family: string, variants: ResolveFontFacesOptions
     numbers.push(style.weight.number)
   }
 
-  if (numbers.length == 0) throw "No available font weights."
+  if (numbers.length === 0) return []
+
   const css = await fontAPI(`/css?f[]=${font.slug + '@' + numbers.join(',')}`)
 
   // TODO: support subsets and axes

--- a/src/providers/fontshare.ts
+++ b/src/providers/fontshare.ts
@@ -103,6 +103,7 @@ async function getFontDetails (family: string, variants: ResolveFontFacesOptions
     numbers.push(style.weight.number)
   }
 
+  if (numbers.length == 0) throw "No available font weights."
   const css = await fontAPI(`/css?f[]=${font.slug + '@' + numbers.join(',')}`)
 
   // TODO: support subsets and axes

--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -76,6 +76,15 @@ async function getFontDetails (family: string, variants: ResolveFontFacesOptions
   const weights = variableWeight
     ? [`${variableWeight.min}..${variableWeight.max}`]
     : variants.weights.filter(weight => String(weight) in font.fonts)
+
+  if (weights.length == 0)
+    throw "No available font weights."
+  else if (
+    (variableWeight && !(variants.weights.every(weight => Number(weight) >= variableWeight.min && Number(weight) <= variableWeight.max))) ||
+    (!variableWeight && variants.weights.length !== weights.length)
+  )
+    logger.warn(`Font weights \`${variants.weights}\` are not entirely available for \`${family}\` from \`google\`.`)
+
   const resolvedVariants = weights.flatMap(w => [...styles].map(s => `${s},${w}`)).sort()
 
   let css = ''

--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -77,13 +77,7 @@ async function getFontDetails (family: string, variants: ResolveFontFacesOptions
     ? [`${variableWeight.min}..${variableWeight.max}`]
     : variants.weights.filter(weight => String(weight) in font.fonts)
 
-  if (weights.length == 0)
-    throw "No available font weights."
-  else if (
-    (variableWeight && !(variants.weights.every(weight => Number(weight) >= variableWeight.min && Number(weight) <= variableWeight.max))) ||
-    (!variableWeight && variants.weights.length !== weights.length)
-  )
-    logger.warn(`Font weights \`${variants.weights}\` are not entirely available for \`${family}\` from \`google\`.`)
+  if (weights.length === 0 || styles.length === 0) return []
 
   const resolvedVariants = weights.flatMap(w => [...styles].map(s => `${s},${w}`)).sort()
 

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -107,6 +107,16 @@ describe('parsing', () => {
   })
 })
 
+describe('error handling', () => {
+  it('handles no font details supplied', async () => {
+    const plugin = FontFamilyInjectionPlugin({
+      dev: true,
+      resolveFontFace: () => ({ fonts: [] })
+    }).raw({}, { framework: 'vite' }) as any
+    expect(await plugin.transform(`:root { font-family: 'Poppins', 'Arial', sans-serif }`).then((r: any) => r?.code)).toMatchInlineSnapshot(`undefined`)
+  })
+})
+
 const slugify = (str: string) => str.toLowerCase().replace(/[^\d\w]/g, '-')
 async function transform (css: string) {
   const plugin = FontFamilyInjectionPlugin({


### PR DESCRIPTION
This pull request warns users when some of the font weights are not available, or throws an error when none of the font weights are available (as the latter situation causes a 400 error with an empty array).