### PR TITLE
 fix: normalize weights before passing to `resolveFontFaces`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -90,7 +90,7 @@ export default defineNuxtModule<ModuleOptions>({
     // Custom merging for defaults - providing a value for any default will override module
     // defaults entirely (to prevent array merging)
     const normalizedDefaults = {
-      weights: options.defaults?.weights || defaultValues.weights,
+      weights: (options.defaults?.weights || defaultValues.weights).map(v => String(v)),
       styles: options.defaults?.styles || defaultValues.styles,
       subsets: options.defaults?.subsets || defaultValues.subsets,
       fallbacks: Object.fromEntries(Object.entries(defaultValues.fallbacks).map(([key, value]) => [
@@ -155,7 +155,7 @@ export default defineNuxtModule<ModuleOptions>({
       const defaults = { ...normalizedDefaults, fallbacks }
       for (const key of ['weights', 'styles', 'subsets'] as const) {
         if (override?.[key]) {
-          defaults[key as 'weights'] = override[key]!
+          defaults[key as 'weights'] = override[key]!.map(v => String(v))
         }
       }
 

--- a/src/providers/fontshare.ts
+++ b/src/providers/fontshare.ts
@@ -95,7 +95,6 @@ function isFontshareFont (family: string) {
 
 async function getFontDetails (family: string, variants: ResolveFontFacesOptions) {
   // https://api.fontshare.com/v2/css?f[]=alpino@300
-  variants.weights = variants.weights.map(String)
   const font = fonts.find(f => f.name === family)!
   const numbers: number[] = []
   for (const style of font.styles) {

--- a/src/providers/fontshare.ts
+++ b/src/providers/fontshare.ts
@@ -95,12 +95,12 @@ function isFontshareFont (family: string) {
 
 async function getFontDetails (family: string, variants: ResolveFontFacesOptions) {
   // https://api.fontshare.com/v2/css?f[]=alpino@300
-  variants.weights = variants.weights.map(Number)
+  variants.weights = variants.weights.map(String)
   const font = fonts.find(f => f.name === family)!
   const numbers: number[] = []
   for (const style of font.styles) {
     if (style.is_italic && !variants.styles.includes('italic')) { continue }
-    if (!variants.weights.includes(style.weight.number)) { continue }
+    if (!variants.weights.includes(String(style.weight.number))) { continue }
     numbers.push(style.weight.number)
   }
 

--- a/src/providers/fontshare.ts
+++ b/src/providers/fontshare.ts
@@ -95,6 +95,7 @@ function isFontshareFont (family: string) {
 
 async function getFontDetails (family: string, variants: ResolveFontFacesOptions) {
   // https://api.fontshare.com/v2/css?f[]=alpino@300
+  variants.weights = variants.weights.map(Number)
   const font = fonts.find(f => f.name === family)!
   const numbers: number[] = []
   for (const style of font.styles) {

--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -75,7 +75,7 @@ async function getFontDetails (family: string, variants: ResolveFontFacesOptions
   const variableWeight = font.axes.find(a => a.tag === 'wght')
   const weights = variableWeight
     ? [`${variableWeight.min}..${variableWeight.max}`]
-    : variants.weights.filter(weight => String(weight) in font.fonts)
+    : variants.weights.filter(weight => weight in font.fonts)
 
   if (weights.length === 0 || styles.length === 0) return []
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,7 +53,7 @@ export interface FontFallback {
 // }
 
 export interface ResolveFontFacesOptions {
-  weights: Array<string | number>
+  weights: string[]
   styles: Array<'normal' | 'italic' | 'oblique'>
   // TODO: improve support and support unicode range
   subsets: string[]
@@ -94,7 +94,7 @@ export interface FontFamilyOverrides {
   // TODO:
   // as?: string
 }
-export interface FontFamilyProviderOverride extends FontFamilyOverrides, Partial<ResolveFontFacesOptions> {
+export interface FontFamilyProviderOverride extends FontFamilyOverrides, Partial<Omit<ResolveFontFacesOptions, 'weights'> & { weights: Array<string | number> }> {
   /** The provider to use when resolving this font. */
   provider?: FontProviderName
 }
@@ -122,7 +122,12 @@ export interface ModuleOptions {
    * ```
    */
   families?: Array<FontFamilyManualOverride | FontFamilyProviderOverride>
-  defaults?: Partial<Omit<ResolveFontFacesOptions, 'fallbacks'>> & { fallbacks?: Partial<Record<GenericCSSFamily, string[]>> }
+  defaults?: Partial<{
+    weights: Array<string | number>
+    styles: ResolveFontFacesOptions['styles']
+    subsets: ResolveFontFacesOptions['subsets']
+    fallbacks?: Partial<Record<GenericCSSFamily, string[]>>
+  }>
   providers?: {
     google?: FontProvider | string | false
     local?: FontProvider | string | false


### PR DESCRIPTION
This PR fixes #46. Just a simple fix which ensures `variants.weights` is composed of numbers.