### PR TITLE
feat: adobe fonts provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,23 @@ Then, when you use a `font-family` in your CSS, we check to see whether it match
 
 You should read [their terms in full](https://www.fontshare.com/licenses/itf-ffl) before using a font through `fontshare`.
 
+### `adobe`
+
+[Adobe Fonts](https://fonts.adobe.com/) is a font service for both personal and commercial use included with Creative Cloud subscriptions.
+
+To configure the Adobe provider in your Nuxt app, you must provide a Project ID or array of Project IDs corresponding to the Web Projects you have created in Adobe Fonts.
+
+```ts
+export default defineNuxtConfig({
+  modules: ['@nuxt/fonts'],
+  fonts: {
+    adobe: {
+      id: ['<some-id>', '<another-kit-id>'],
+    },
+  }
+})
+```
+
 ### Writing a custom provider
 
 The provider API is likely to evolve in the next few releases of Nuxt Fonts, but at the moment it looks like this:

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -19,7 +19,7 @@ export default defineNuxtConfig({
       { name: 'Aleo', provider: 'adobe'}
     ],
     adobe: {
-      id: "sij5ufr",
+      id: 'sij5ufr',
     },
     defaults: {
       fallbacks: {

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -17,6 +17,9 @@ export default defineNuxtConfig({
       { name: 'CustomGlobal', global: true, src: '/font-global.woff2' },
       { name: 'Oswald', fallbacks: ['Times New Roman'] },
     ],
+    adobe: {
+      id: "sij5ufr",
+    },
     defaults: {
       fallbacks: {
         monospace: ['Tahoma']

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -17,7 +17,7 @@ export default defineNuxtConfig({
       { name: 'CustomGlobal', global: true, src: '/font-global.woff2' },
       { name: 'Oswald', fallbacks: ['Times New Roman'] },
       { name: 'Aleo', provider: 'adobe'},
-      { name: 'barlow-semi-condensed', provider: 'adobe' }
+      { name: 'Barlow Semi Condensed', provider: 'adobe' }
     ],
     adobe: {
       id: ['sij5ufr', 'grx7wdj'],

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -16,6 +16,7 @@ export default defineNuxtConfig({
       { name: 'MyCustom', src: '/custom-font.woff2' },
       { name: 'CustomGlobal', global: true, src: '/font-global.woff2' },
       { name: 'Oswald', fallbacks: ['Times New Roman'] },
+      { name: 'Aleo', provider: 'adobe'}
     ],
     adobe: {
       id: "sij5ufr",

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -16,10 +16,11 @@ export default defineNuxtConfig({
       { name: 'MyCustom', src: '/custom-font.woff2' },
       { name: 'CustomGlobal', global: true, src: '/font-global.woff2' },
       { name: 'Oswald', fallbacks: ['Times New Roman'] },
-      { name: 'Aleo', provider: 'adobe'}
+      { name: 'Aleo', provider: 'adobe'},
+      { name: 'barlow-semi-condensed', provider: 'adobe' }
     ],
     adobe: {
-      id: 'sij5ufr',
+      id: ['sij5ufr', 'grx7wdj'],
     },
     defaults: {
       fallbacks: {

--- a/playground/pages/providers/adobe.vue
+++ b/playground/pages/providers/adobe.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    Nuxt module playground!
+  </div>
+</template>
+
+<style scoped>
+div {
+  font-family: 'Aleo', sans-serif;
+}
+</style>

--- a/playground/pages/providers/adobe2.vue
+++ b/playground/pages/providers/adobe2.vue
@@ -6,6 +6,6 @@
 
 <style scoped>
 div {
-  font-family: 'barlow-semi-condensed', sans-serif;
+  font-family: 'Barlow Semi Condensed', sans-serif;
 }
 </style>

--- a/playground/pages/providers/adobe2.vue
+++ b/playground/pages/providers/adobe2.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    Nuxt module playground!
+  </div>
+</template>
+
+<style scoped>
+div {
+  font-family: 'barlow-semi-condensed', sans-serif;
+}
+</style>

--- a/src/css/parse.ts
+++ b/src/css/parse.ts
@@ -13,8 +13,13 @@ const extractableKeyMap: Record<string, keyof NormalizedFontFaceData> = {
   'unicode-range': 'unicodeRange',
 }
 
-export function extractFontFaceData (css: string): NormalizedFontFaceData[] {
+export function extractFontFaceData (css: string, family?: string): NormalizedFontFaceData[] {
   const fontFaces: NormalizedFontFaceData[] = []
+
+  if (family) {
+    const fontFaceRegex = new RegExp(`@font-face\\s*{[^}]*font-family:\\s*["']${family.toLowerCase()}["'][^}]*}`, 'g');
+    css = css.match(fontFaceRegex)!.join('\n')
+  }
 
   for (const node of findAll(parse(css), node => node.type === 'Atrule' && node.name === 'font-face')) {
     if (node.type !== 'Atrule' || node.name !== 'font-face') { continue }

--- a/src/module.ts
+++ b/src/module.ts
@@ -7,6 +7,7 @@ import local from './providers/local'
 import google from './providers/google'
 import bunny from './providers/bunny'
 import fontshare from './providers/fontshare'
+import adobe from './providers/adobe'
 
 import { FontFamilyInjectionPlugin, type FontFaceResolution } from './plugins/transform'
 import { generateFontFace } from './css/render'
@@ -85,8 +86,12 @@ export default defineNuxtModule<ModuleOptions>({
     },
     local: {},
     google: {},
+    adobe: {
+      id: '',
+    },
     providers: {
       local,
+      adobe,
       google,
       bunny,
       fontshare,
@@ -128,7 +133,7 @@ export default defineNuxtModule<ModuleOptions>({
         if (options.providers?.[key] === false || (options.provider && options.provider !== key)) {
           delete providers[key]
         } else if (provider.setup) {
-          setups.push(provider.setup(options[key as 'google' | 'local'] || {}, nuxt))
+          setups.push(provider.setup(options[key as 'google' | 'local' | 'adobe'] || {}, nuxt))
         }
       }
       await Promise.all(setups)

--- a/src/providers/adobe.ts
+++ b/src/providers/adobe.ts
@@ -1,0 +1,91 @@
+import { $fetch } from 'ofetch'
+import { hash } from 'ohash'
+
+import type { FontProvider, ResolveFontFacesOptions } from '../types'
+import { extractFontFaceData, addLocalFallbacks } from '../css/parse'
+import { cachedData } from '../cache'
+import { logger } from '../logger'
+
+interface ProviderOption {
+  id?: string
+}
+
+export default {
+  async setup (providerOption: ProviderOption) {
+    await initialiseFontMeta(providerOption.id!)
+  },
+  async resolveFontFaces (fontFamily, defaults) {
+    if (!isAdobeFont(fontFamily)) { return }
+
+    return {
+      fonts: await cachedData(`adobe:${fontFamily}-${hash(defaults)}-data.json`, () => getFontDetails(fontFamily, defaults), {
+        onError (err) {
+          logger.error(`Could not fetch metadata for \`${fontFamily}\` from \`bunny\`.`, err)
+          return []
+        }
+      })
+    }
+  },
+} satisfies FontProvider
+
+const fontAPI = $fetch.create({
+  baseURL: 'https://typekit.com'
+})
+
+const fontCSSAPI = $fetch.create({
+  baseURL: 'https://use.typekit.net'
+})
+
+interface AdobeFontMeta {
+  kit: AdobeFontKit
+}
+
+interface AdobeFontKit {
+  id: string
+  families: AdobeFontFamily[]
+}
+
+interface AdobeFontFamily {
+  id: string
+  name: string
+  slug: string
+  css_names: string[]
+  css_stack: string
+  variations: string[]
+}
+
+let fonts: AdobeFontMeta
+const familyMap = new Map<string, string>()
+
+async function initialiseFontMeta (kitId: string) {
+  fonts = await cachedData('adobe:meta.json', () => fontAPI<AdobeFontMeta>(`/api/v1/json/kits/${kitId}/published`, { responseType: 'json' }), {
+    onError () {
+      logger.error('Could not download `adobe` font metadata. `@nuxt/fonts` will not be able to inject `@font-face` rules for adobe.')
+      return {kit: { id: '', families: [] } }
+    }
+  })
+  for (const family in fonts.kit.families) {
+    familyMap.set(fonts.kit.families[family]!.name, fonts.kit.families[family]!.id)
+  }
+}
+
+function isAdobeFont (family: string) {
+  return familyMap.has(family)
+}
+
+async function getFontDetails (family: string, variants: ResolveFontFacesOptions) {
+  variants.weights = variants.weights.map(String)
+  const font = fonts.kit.families.find(f => f.name === family)!
+  const styles: string[] = []
+  for (const style of font.variations) {
+    if (style.includes('i') && !variants.styles.includes('italic')) { continue }
+    if (!variants.weights.includes(String(style.slice(-1)+'00'))) { continue }
+    styles.push(style)
+  }
+
+  if (styles.length === 0) return []
+  const fontFaceRegex = new RegExp(`@font-face\\s*{[^}]*font-family:\\s*["']${family.toLowerCase()}["'][^}]*}`, 'g');
+  const css = (await fontCSSAPI(`${fonts.kit.id}.css`)).match(fontFaceRegex).join('\n')
+
+  return addLocalFallbacks(family, extractFontFaceData(css))
+}

--- a/src/providers/adobe.ts
+++ b/src/providers/adobe.ts
@@ -7,7 +7,7 @@ import { cachedData } from '../cache'
 import { logger } from '../logger'
 
 interface ProviderOption {
-  id?: string
+  id?: string[] | string
 }
 
 export default {
@@ -38,6 +38,10 @@ const fontCSSAPI = $fetch.create({
 })
 
 interface AdobeFontMeta {
+  kit: AdobeFontKit[]
+}
+
+interface AdobeFontAPI {
   kit: AdobeFontKit
 }
 
@@ -58,15 +62,34 @@ interface AdobeFontFamily {
 let fonts: AdobeFontMeta
 const familyMap = new Map<string, string>()
 
-async function initialiseFontMeta (kitId: string) {
-  fonts = await cachedData('adobe:meta.json', () => fontAPI<AdobeFontMeta>(`/api/v1/json/kits/${kitId}/published`, { responseType: 'json' }), {
+async function getAdobeFontMeta (kitId: string | string[]):Promise<AdobeFontMeta> {
+  if (typeof kitId === "string")
+    return {
+      kit: [
+        (await fontAPI<AdobeFontAPI>(`/api/v1/json/kits/${kitId}/published`, { responseType: 'json' })).kit
+      ]
+    }
+
+  const metadata: AdobeFontMeta = { kit: [] }
+
+  for (const kit in kitId) {
+    metadata.kit.push((await fontAPI<AdobeFontAPI>(`/api/v1/json/kits/${kitId[kit]}/published`, { responseType: 'json' })).kit)
+  }
+
+  return metadata
+}
+
+async function initialiseFontMeta (kitId: string | string[]) {
+  fonts = await cachedData('adobe:meta.json', () => getAdobeFontMeta(kitId), {
     onError () {
       logger.error('Could not download `adobe` font metadata. `@nuxt/fonts` will not be able to inject `@font-face` rules for adobe.')
-      return { kit: { id: '', families: [] } }
+      return { kit: [] }
     }
   })
-  for (const family in fonts.kit.families) {
-    familyMap.set(fonts.kit.families[family]!.name, fonts.kit.families[family]!.id)
+  for (const kit in fonts.kit) {
+    for (const family in fonts.kit[kit]!.families) {
+      familyMap.set(fonts.kit[kit]!.families[family]!.slug, fonts.kit[kit]!.families[family]!.id)
+    }
   }
 }
 
@@ -76,16 +99,25 @@ function isAdobeFont (family: string) {
 
 async function getFontDetails (family: string, variants: ResolveFontFacesOptions) {
   variants.weights = variants.weights.map(String)
-  const font = fonts.kit.families.find(f => f.name === family)!
-  const styles: string[] = []
-  for (const style of font.variations) {
-    if (style.includes('i') && !variants.styles.includes('italic')) { continue }
-    if (!variants.weights.includes(String(style.slice(-1)+'00'))) { continue }
-    styles.push(style)
+
+  for (const kit in fonts.kit) {
+    const font = fonts.kit[kit]!.families.find(f => f.slug === family)!
+    if (!font) { continue }
+
+    const styles: string[] = []
+    for (const style of font.variations) {
+      if (style.includes('i') && !variants.styles.includes('italic')) {
+        continue
+      }
+      if (!variants.weights.includes(String(style.slice(-1) + '00'))) {
+        continue
+      }
+      styles.push(style)
+    }
+    if (styles.length === 0) { continue }
+    const css = await fontCSSAPI(`${fonts.kit[kit]!.id}.css`)
+    return addLocalFallbacks(family, extractFontFaceData(css, family))
   }
 
-  if (styles.length === 0) return []
-  const css = await fontCSSAPI(`${fonts.kit.id}.css`)
-
-  return addLocalFallbacks(family, extractFontFaceData(css, family))
+  return []
 }

--- a/src/providers/adobe.ts
+++ b/src/providers/adobe.ts
@@ -88,7 +88,7 @@ async function initialiseFontMeta (kitId: string | string[]) {
   })
   for (const kit in fonts.kit) {
     for (const family in fonts.kit[kit]!.families) {
-      familyMap.set(fonts.kit[kit]!.families[family]!.slug, fonts.kit[kit]!.families[family]!.id)
+      familyMap.set(fonts.kit[kit]!.families[family]!.name, fonts.kit[kit]!.families[family]!.id)
     }
   }
 }
@@ -101,7 +101,7 @@ async function getFontDetails (family: string, variants: ResolveFontFacesOptions
   variants.weights = variants.weights.map(String)
 
   for (const kit in fonts.kit) {
-    const font = fonts.kit[kit]!.families.find(f => f.slug === family)!
+    const font = fonts.kit[kit]!.families.find(f => f.name === family)!
     if (!font) { continue }
 
     const styles: string[] = []
@@ -116,7 +116,10 @@ async function getFontDetails (family: string, variants: ResolveFontFacesOptions
     }
     if (styles.length === 0) { continue }
     const css = await fontCSSAPI(`${fonts.kit[kit]!.id}.css`)
-    return addLocalFallbacks(family, extractFontFaceData(css, family))
+
+    // Adobe uses slugs instead of names in its CSS to define its font faces, so we need to first transform names into slugs.
+    const slug = family.toLowerCase().split(' ').join('-')
+    return addLocalFallbacks(family, extractFontFaceData(css, slug))
   }
 
   return []

--- a/src/providers/adobe.ts
+++ b/src/providers/adobe.ts
@@ -38,7 +38,7 @@ const fontCSSAPI = $fetch.create({
 })
 
 interface AdobeFontMeta {
-  kit: AdobeFontKit[]
+  kits: AdobeFontKit[]
 }
 
 interface AdobeFontAPI {
@@ -65,15 +65,15 @@ const familyMap = new Map<string, string>()
 async function getAdobeFontMeta (kitId: string | string[]):Promise<AdobeFontMeta> {
   if (typeof kitId === "string")
     return {
-      kit: [
+      kits: [
         (await fontAPI<AdobeFontAPI>(`/api/v1/json/kits/${kitId}/published`, { responseType: 'json' })).kit
       ]
     }
 
-  const metadata: AdobeFontMeta = { kit: [] }
+  const metadata: AdobeFontMeta = { kits: [] }
 
   for (const kit in kitId) {
-    metadata.kit.push((await fontAPI<AdobeFontAPI>(`/api/v1/json/kits/${kitId[kit]}/published`, { responseType: 'json' })).kit)
+    metadata.kits.push((await fontAPI<AdobeFontAPI>(`/api/v1/json/kits/${kitId[kit]}/published`, { responseType: 'json' })).kit)
   }
 
   return metadata
@@ -83,12 +83,12 @@ async function initialiseFontMeta (kitId: string | string[]) {
   fonts = await cachedData('adobe:meta.json', () => getAdobeFontMeta(kitId), {
     onError () {
       logger.error('Could not download `adobe` font metadata. `@nuxt/fonts` will not be able to inject `@font-face` rules for adobe.')
-      return { kit: [] }
+      return { kits: [] }
     }
   })
-  for (const kit in fonts.kit) {
-    for (const family in fonts.kit[kit]!.families) {
-      familyMap.set(fonts.kit[kit]!.families[family]!.name, fonts.kit[kit]!.families[family]!.id)
+  for (const kit in fonts.kits) {
+    for (const family in fonts.kits[kit]!.families) {
+      familyMap.set(fonts.kits[kit]!.families[family]!.name, fonts.kits[kit]!.families[family]!.id)
     }
   }
 }
@@ -100,8 +100,8 @@ function isAdobeFont (family: string) {
 async function getFontDetails (family: string, variants: ResolveFontFacesOptions) {
   variants.weights = variants.weights.map(String)
 
-  for (const kit in fonts.kit) {
-    const font = fonts.kit[kit]!.families.find(f => f.name === family)!
+  for (const kit in fonts.kits) {
+    const font = fonts.kits[kit]!.families.find(f => f.name === family)!
     if (!font) { continue }
 
     const styles: string[] = []
@@ -115,7 +115,7 @@ async function getFontDetails (family: string, variants: ResolveFontFacesOptions
       styles.push(style)
     }
     if (styles.length === 0) { continue }
-    const css = await fontCSSAPI(`${fonts.kit[kit]!.id}.css`)
+    const css = await fontCSSAPI(`${fonts.kits[kit]!.id}.css`)
 
     // Adobe uses slugs instead of names in its CSS to define its font faces, so we need to first transform names into slugs.
     const slug = family.toLowerCase().split(' ').join('-')

--- a/src/providers/adobe.ts
+++ b/src/providers/adobe.ts
@@ -20,7 +20,7 @@ export default {
     return {
       fonts: await cachedData(`adobe:${fontFamily}-${hash(defaults)}-data.json`, () => getFontDetails(fontFamily, defaults), {
         onError (err) {
-          logger.error(`Could not fetch metadata for \`${fontFamily}\` from \`bunny\`.`, err)
+          logger.error(`Could not fetch metadata for \`${fontFamily}\` from \`adobe\`.`, err)
           return []
         }
       })

--- a/src/providers/adobe.ts
+++ b/src/providers/adobe.ts
@@ -84,8 +84,7 @@ async function getFontDetails (family: string, variants: ResolveFontFacesOptions
   }
 
   if (styles.length === 0) return []
-  const fontFaceRegex = new RegExp(`@font-face\\s*{[^}]*font-family:\\s*["']${family.toLowerCase()}["'][^}]*}`, 'g');
-  const css = (await fontCSSAPI(`${fonts.kit.id}.css`)).match(fontFaceRegex).join('\n')
+  const css = await fontCSSAPI(`${fonts.kit.id}.css`)
 
-  return addLocalFallbacks(family, extractFontFaceData(css))
+  return addLocalFallbacks(family, extractFontFaceData(css, family))
 }

--- a/src/providers/adobe.ts
+++ b/src/providers/adobe.ts
@@ -12,6 +12,7 @@ interface ProviderOption {
 
 export default {
   async setup (providerOption: ProviderOption) {
+    if (!providerOption.id) { return }
     await initialiseFontMeta(providerOption.id!)
   },
   async resolveFontFaces (fontFamily, defaults) {
@@ -61,7 +62,7 @@ async function initialiseFontMeta (kitId: string) {
   fonts = await cachedData('adobe:meta.json', () => fontAPI<AdobeFontMeta>(`/api/v1/json/kits/${kitId}/published`, { responseType: 'json' }), {
     onError () {
       logger.error('Could not download `adobe` font metadata. `@nuxt/fonts` will not be able to inject `@font-face` rules for adobe.')
-      return {kit: { id: '', families: [] } }
+      return { kit: { id: '', families: [] } }
     }
   })
   for (const family in fonts.kit.families) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,6 +149,10 @@ export interface ModuleOptions {
   google?: {}
   /** Options passed directly to `local` font provider (none currently) */
   local?: {}
+  /** Options passed directly to `adobe` font provider */
+  adobe?: {
+    id: string
+  }
   /**
    * An ordered list of providers to check when resolving font families.
    *

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,7 +151,7 @@ export interface ModuleOptions {
   local?: {}
   /** Options passed directly to `adobe` font provider */
   adobe?: {
-    id: string
+    id: string | string[]
   }
   /**
    * An ordered list of providers to check when resolving font families.


### PR DESCRIPTION
This PR resolves #11. What is different from the proposal written in the issue is that when a font is matched in the kit, a regex filters out the `@font-face` declarations that are not related to the font requested.

I think the next thing we can work on this provider is to work with different kit IDs and treat them like separate providers.