### PR TITLE
feat(provider): provide options to disable `addLocalFallbacks`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -13,7 +13,7 @@ import { FontFamilyInjectionPlugin, type FontFaceResolution } from './plugins/tr
 import { generateFontFace } from './css/render'
 import type { GenericCSSFamily } from './css/parse'
 import { setupPublicAssetStrategy } from './assets'
-import type { FontFamilyManualOverride, FontFamilyProviderOverride, FontProvider, ModuleHooks, ModuleOptions } from './types'
+import type { FontFamilyManualOverride, FontFamilyProviderOverride, FontProvider, ModuleHooks, ModuleOptions, ResolveFontFacesOptions } from './types'
 import { setupDevtoolsConnection } from './devtools'
 import { logger } from './logger'
 import { withoutLeadingSlash } from 'ufo'
@@ -66,7 +66,8 @@ const defaultValues = {
     'emoji': [],
     'math': [],
     'fangsong': [],
-  }
+  },
+  disableLocalFallbacks: false,
 } satisfies ModuleOptions['defaults']
 
 export default defineNuxtModule<ModuleOptions>({
@@ -110,7 +111,8 @@ export default defineNuxtModule<ModuleOptions>({
       fallbacks: Object.fromEntries(Object.entries(defaultValues.fallbacks).map(([key, value]) => [
         key,
         Array.isArray(options.defaults?.fallbacks) ? options.defaults.fallbacks : options.defaults?.fallbacks?.[key as GenericCSSFamily] || value
-      ])) as Record<GenericCSSFamily, string[]>
+      ])) as Record<GenericCSSFamily, string[]>,
+      disableLocalFallbacks: options.defaults?.disableLocalFallbacks || defaultValues.disableLocalFallbacks
     }
 
     if (!options.defaults?.fallbacks || !Array.isArray(options.defaults.fallbacks)) {
@@ -173,7 +175,7 @@ export default defineNuxtModule<ModuleOptions>({
       if (override?.provider === 'none') { return }
 
       // Respect custom weights, styles and subsets options
-      const defaults = { ...normalizedDefaults, fallbacks }
+      const defaults = { ...normalizedDefaults, fallbacks } as ResolveFontFacesOptions
       for (const key of ['weights', 'styles', 'subsets'] as const) {
         if (override?.[key]) {
           defaults[key as 'weights'] = override[key]!.map(v => String(v))

--- a/src/providers/adobe.ts
+++ b/src/providers/adobe.ts
@@ -111,7 +111,9 @@ async function getFontDetails (family: string, variants: ResolveFontFacesOptions
     // Adobe uses slugs instead of names in its CSS to define its font faces,
     // so we need to first transform names into slugs.
     const slug = family.toLowerCase().split(' ').join('-')
-    return addLocalFallbacks(family, extractFontFaceData(css, slug))
+
+    if (variants.disableLocalFallbacks) { return extractFontFaceData(css, slug) }
+    else { return addLocalFallbacks(family, extractFontFaceData(css, slug)) }
   }
 
   return []

--- a/src/providers/bunny.ts
+++ b/src/providers/bunny.ts
@@ -82,5 +82,6 @@ async function getFontDetails (family: string, variants: ResolveFontFacesOptions
   })
 
   // TODO: support subsets
-  return addLocalFallbacks(family, extractFontFaceData(css))
+  if (variants.disableLocalFallbacks) { return extractFontFaceData(css) }
+  else { return addLocalFallbacks(family, extractFontFaceData(css)) }
 }

--- a/src/providers/fontshare.ts
+++ b/src/providers/fontshare.ts
@@ -108,5 +108,6 @@ async function getFontDetails (family: string, variants: ResolveFontFacesOptions
   const css = await fontAPI(`/css?f[]=${font.slug + '@' + numbers.join(',')}`)
 
   // TODO: support subsets and axes
-  return addLocalFallbacks(family, extractFontFaceData(css))
+  if (variants.disableLocalFallbacks) { return extractFontFaceData(css) }
+  else { return addLocalFallbacks(family, extractFontFaceData(css)) }
 }

--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -94,7 +94,8 @@ async function getFontDetails (family: string, variants: ResolveFontFacesOptions
   }
 
   // TODO: support subsets
-  return addLocalFallbacks(family, extractFontFaceData(css))
+  if (variants.disableLocalFallbacks) { return extractFontFaceData(css) }
+  else { return addLocalFallbacks(family, extractFontFaceData(css)) }
 }
 
 const userAgents = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,7 @@ export interface ResolveFontFacesOptions {
   // TODO: improve support and support unicode range
   subsets: string[]
   fallbacks: string[]
+  disableLocalFallbacks: boolean
 }
 
 export interface FontProvider<FontProviderOptions = Record<string, unknown>> {
@@ -129,6 +130,7 @@ export interface ModuleOptions {
     styles: ResolveFontFacesOptions['styles']
     subsets: ResolveFontFacesOptions['subsets']
     fallbacks?: Partial<Record<GenericCSSFamily, string[]>>
+    disableLocalFallbacks: boolean
   }>
   providers?: {
     google?: FontProvider | string | false

--- a/test/providers/local.test.ts
+++ b/test/providers/local.test.ts
@@ -22,7 +22,8 @@ describe('local font provider', () => {
       fallbacks: [],
       weights: ['normal'],
       styles: ['normal'],
-      subsets: ['latin']
+      subsets: ['latin'],
+      disableLocalFallbacks: false,
     })
     expect(faces).toMatchInlineSnapshot(`
       {

--- a/test/providers/local.test.ts
+++ b/test/providers/local.test.ts
@@ -61,7 +61,8 @@ describe('local font provider', () => {
       fallbacks: [],
       weights: ['normal'],
       styles: ['normal'],
-      subsets: ['latin']
+      subsets: ['latin'],
+      disableLocalFallbacks: false,
     })?.fonts).toMatchInlineSnapshot(`
       [
         {
@@ -78,7 +79,8 @@ describe('local font provider', () => {
       fallbacks: [],
       weights: ['bold'],
       styles: ['normal'],
-      subsets: ['latin']
+      subsets: ['latin'],
+      disableLocalFallbacks: false,
     })?.fonts).toMatchInlineSnapshot(`
       [
         {
@@ -97,7 +99,8 @@ describe('local font provider', () => {
       fallbacks: [],
       weights: ['extra-light'],
       styles: ['normal'],
-      subsets: ['latin']
+      subsets: ['latin'],
+      disableLocalFallbacks: false,
     })?.fonts).toMatchInlineSnapshot(`
       [
         {


### PR DESCRIPTION
This PR adds a `disableLocalFallbacks` option in `fonts.defaults`.