### PR TITLE
fix: continue if font family doesn't match in `getFontDetails`

### DIFF
--- a/src/css/parse.ts
+++ b/src/css/parse.ts
@@ -39,7 +39,7 @@ export function extractFontFaceData (css: string, family?: string): NormalizedFo
 
     if (family) {
       const isCorrectFontFace = node.block?.children.some(child => {
-        if (child.type !== 'Declaration' || child.property !== 'font-family') return false
+        if (child.type !== 'Declaration' || child.property !== 'font-family') { return false }
 
         const value = extractCSSValue(child) as string | string[]
         const slug = family.toLowerCase()

--- a/src/css/parse.ts
+++ b/src/css/parse.ts
@@ -34,7 +34,7 @@ const styleMap: Record<string, string> = {
 export function extractFontFaceData (css: string, family?: string): NormalizedFontFaceData[] {
   const fontFaces: NormalizedFontFaceData[] = []
 
-  for (const node of findAll(parse(css), node => node.type === 'Atrule' && node.name === 'font-face')) {
+  loopNodes: for (const node of findAll(parse(css), node => node.type === 'Atrule' && node.name === 'font-face')) {
     if (node.type !== 'Atrule' || node.name !== 'font-face') { continue }
 
     const data: Partial<NormalizedFontFaceData> = {}
@@ -44,7 +44,7 @@ export function extractFontFaceData (css: string, family?: string): NormalizedFo
         const value = extractCSSValue(child) as string | string[]
         const slug = family.toLowerCase()
         if (typeof value === 'string' && value.toLowerCase() !== slug) {
-          return []
+          continue loopNodes
         }
         if (Array.isArray(value) && value.length > 0 && value.every(v => v.toLowerCase() !== slug)) {
           return []


### PR DESCRIPTION
Just a simple fix; this PR modifies `getFontDetails` so that it continues the loop instead of break if font family doesn't match because the input CSS might have font families other than the requested one. This fixes the "Could not produce font face declaration from adobe for font family Barlow Semi Condensed." error in the playground as I have multiple fonts in that kit.