### PR TITLE
fix: adopt forward-compatible approach to `builder:watch`

### DIFF
--- a/src/providers/local.ts
+++ b/src/providers/local.ts
@@ -1,3 +1,4 @@
+import {  } from 'node:path'
 import { globby } from 'globby'
 import { join, relative, resolve } from 'pathe'
 import { filename } from 'pathe/utils'
@@ -31,6 +32,7 @@ export default {
 
     // Update registry when files change
     nuxt.hook('builder:watch', (event, relativePath) => {
+      relativePath = relative(nuxt.options.srcDir, resolve(nuxt.options.srcDir, relativePath))
       const path = resolve(nuxt.options.srcDir, relativePath)
       if (event === 'add' && isFontFile(path)) {
         registerFont(path)

--- a/src/providers/local.ts
+++ b/src/providers/local.ts
@@ -1,4 +1,3 @@
-import {  } from 'node:path'
 import { globby } from 'globby'
 import { join, relative, resolve } from 'pathe'
 import { filename } from 'pathe/utils'


### PR DESCRIPTION
We are planning to move to [emitting absolute paths in `builder:watch` in Nuxt v4](https://github.com/nuxt/nuxt/issues/25339). You can see a little more about the history in the PR linked in that issue.

This PR is an attempt to use a forward/backward compatible approach, namely resolving the path to ensure it's absolute, then making it relative so your existing code will continue to work.

This should be safe to merge as is, but do let me know if you have any concerns about this approach.

