### PR TITLE
docs: mention non-latin subset support for adobe provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,9 @@ export default defineNuxtConfig({
 })
 ```
 
+> [!WARNING]
+> We currently can't provide non-latin subsets for Adobe Fonts as they do not have a public API for that. Please use other providers in such cases.
+
 ### Writing a custom provider
 
 The provider API is likely to evolve in the next few releases of Nuxt Fonts, but at the moment it looks like this:


### PR DESCRIPTION
Closes #105.