### PR TITLE
fix(adobe): use provided `css_names` from API

### DIFF
--- a/src/providers/adobe.ts
+++ b/src/providers/adobe.ts
@@ -116,10 +116,10 @@ async function getFontDetails(family: string, variants: ResolveFontFacesOptions)
     }
     const css = await fontCSSAPI<string>(`${fonts.kits[kit]!.id}.css`)
 
-    // Adobe uses slugs instead of names in its CSS to define its font faces,
-    // so we need to first transform names into slugs.
-    const slug = family.toLowerCase().split(' ').join('-')
-    return addLocalFallbacks(family, extractFontFaceData(css, slug))
+    // TODO: Not sure whether this css_names array always has a single element. Still need to investigate.
+    const cssName = font.css_names[0]!
+
+    return addLocalFallbacks(family, extractFontFaceData(css, cssName))
   }
 
   return []

--- a/src/providers/adobe.ts
+++ b/src/providers/adobe.ts
@@ -117,7 +117,7 @@ async function getFontDetails(family: string, variants: ResolveFontFacesOptions)
     const css = await fontCSSAPI<string>(`${fonts.kits[kit]!.id}.css`)
 
     // TODO: Not sure whether this css_names array always has a single element. Still need to investigate.
-    const cssName = font.css_names[0]!
+    const cssName = font.css_names[0] ?? family.toLowerCase().split(' ').join('-')
 
     return addLocalFallbacks(family, extractFontFaceData(css, cssName))
   }


### PR DESCRIPTION
@danielroe 

This PR resolves #187. I'm not sure whether this `css_names` always have a single value, it's not documented anywhere.