### PR TITLE
docs: fix link how it works

### DIFF
--- a/docs/content/1.get-started/1.installation.md
+++ b/docs/content/1.get-started/1.installation.md
@@ -63,7 +63,7 @@ div {
 </style>
 ```
 
-That's it! Nuxt Fonts will detect this and you should immediately see the web font loaded in your browser. [Read more about how it works](#how-it-works).
+That's it! Nuxt Fonts will detect this and you should immediately see the web font loaded in your browser. [Read more about how it works](/advanced#how-it-works).
 
 ::callout
 Check out the [configuration docs](/get-started/configuration) for all available options and features to customize.


### PR DESCRIPTION
Fixing a bad link which pointing the guide of how nuxt fonts works