### PR TITLE
fix: add global `preload` links to entry chunk

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -295,8 +295,11 @@ export default defineNuxtModule<ModuleOptions>({
       }
 
       // CSS files in bundle
-      for (const id in manifest) {
-        const chunk = manifest[id]!
+      let entry: ResourceMeta | undefined
+      for (const chunk of Object.values(manifest)) {
+        if (chunk.isEntry && chunk.src === viteEntry) {
+          entry = chunk
+        }
         if (!chunk.css || chunk.css.length === 0) continue
         for (const css of chunk.css) {
           const assetName = withoutLeadingSlash(join(nuxt.options.app.buildAssetsDir, css))
@@ -307,7 +310,6 @@ export default defineNuxtModule<ModuleOptions>({
       }
 
       // Source files in bundle
-      const entry = Object.values(manifest).find(c => c.isEntry && c.src === viteEntry)
       for (const [id, urls] of fontMap) {
         const chunk = manifest[relative(nuxt.options.srcDir, id)] ?? entry
         if (!chunk) continue


### PR DESCRIPTION
resolves https://github.com/nuxt/fonts/issues/152

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
