### PR TITLE
fix: scan font families declared in `font:`

### DIFF
--- a/playground/pages/providers/google.vue
+++ b/playground/pages/providers/google.vue
@@ -11,7 +11,7 @@
 
 <style scoped>
 div {
-  font-family: 'Poppins', Raleway, sans-serif;
+  font: 1.2em 'Poppins', sans-serif;
 }
 
 p {

--- a/src/plugins/transform.ts
+++ b/src/plugins/transform.ts
@@ -116,7 +116,7 @@ export const FontFamilyInjectionPlugin = (options: FontFamilyInjectionPluginOpti
     walk(ast, {
       visit: 'Declaration',
       enter(node) {
-        if ((node.property !== 'font-family' && (!options.processCSSVariables || !node.property.startsWith('--'))) || this.atrule?.name === 'font-face') {
+        if (((node.property !== 'font-family' && node.property !== 'font') && (!options.processCSSVariables || !node.property.startsWith('--'))) || this.atrule?.name === 'font-face') {
           return
         }
 

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -17,6 +17,18 @@ describe('parsing', () => {
       `)
   })
 
+  it('should add declarations for `font`', async () => {
+    expect(await transform(`:root { font: 1.2em 'CustomFont' }`))
+      .toMatchInlineSnapshot(`
+        "@font-face {
+          font-family: 'CustomFont';
+          src: url("/customfont.woff2") format(woff2);
+          font-display: swap;
+        }
+        :root { font: 1.2em 'CustomFont' }"
+      `)
+  })
+
   it('should add declarations for `font-family` with CSS variables', async () => {
     expect(await transform(`:root { --custom-css-variable: 'CustomFont' }`))
       .toMatchInlineSnapshot(`


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->

@danielroe 

Resolves #291. `css-tree` does the parsing work automatically for us.
