### PR TITLE
fix: write stub files in cache to trigger public asset handling

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -161,7 +161,7 @@ export default defineNuxtModule<ModuleOptions>({
       unifont = await createUnifont(resolvedProviders, { storage })
     })
 
-    const { normalizeFontData } = setupPublicAssetStrategy(options.assets)
+    const { normalizeFontData } = await setupPublicAssetStrategy(options.assets)
     const { exposeFont } = setupDevtoolsConnection(nuxt.options.dev && !!options.devtools)
 
     function addFallbacks(fontFamily: string, font: FontFaceData[]) {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/fonts/issues/341
resolves https://github.com/nuxt/fonts/issues/224

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

owing to how Nuxt attempts to handle public assets, it checks if a file _exists_ at the time of rendering the chunk.

in the first build of a site using Nuxt fonts, these files do not exist in the cache directory and so Nuxt will hard code these as `/_fonts/*`. subsequently they will exist and dynamic urls work (making reproductions harder).

this PR is a workaround, writing stub data at build-time to ensure the Nuxt handler picks up these urls as pointing to public files.