### PR TITLE
docs: Add examples to local file lookup docs

### DIFF
--- a/docs/content/1.get-started/4.providers.md
+++ b/docs/content/1.get-started/4.providers.md
@@ -11,7 +11,7 @@ Nuxt Fonts ships with a number of built-in providers.
 
 The local provider deeply scans your `public/` directories (including of your layers) for font files (supporting `ttf`, `woff`, `woff2`, `eot` or `otf` extensions).
 
-Then, when you use a `font-family` in your CSS, we check to see whether it matches one of these files. By default, we expect the font file to be the `400` weight, `normal` style, and `latin` subset. To indicate different weights and styles, please include that information in the filename. For example `comic-sans-ms.woff2` (400/normal/latin; defaults), `comic-sans-ms-700-italic-cyrillic.woff2` (700/italic/cyrillic). `font-family` values with spaces and/or caps will lookup hyphenated lowercase filenames as well.
+Then, when you use a `font-family` in your CSS, we check to see whether it matches one of these files. By default, we expect the font file to be the `400` weight, `normal` style, and `latin` subset. To indicate different weights and styles, please include that information in the filename. For example `comic-sans-ms.woff2` (400/normal/latin; defaults), `comic-sans-ms-700-italic-cyrillic.woff2` (700/italic/cyrillic). Keywords like `light`, `bold`, or `black` are accepted in place of a weight number: `comic-sans-ms-bold.woff2`. `font-family` values with spaces and/or caps will lookup hyphenated lowercase filenames as well, eg `font-family: 'Comic Sans MS'` will look for `comic-sans-ms.woff2` as well as `Comic\ Sans\ MS.woff2` on disk.
 
 
 ### `google`

--- a/docs/content/1.get-started/4.providers.md
+++ b/docs/content/1.get-started/4.providers.md
@@ -9,9 +9,10 @@ Nuxt Fonts ships with a number of built-in providers.
 
 ### `local`
 
-The local provider deeply scans your `public/` directories (including of your layers) for font files (supporting ttf, woff, woff2, eot or otf extensions).
+The local provider deeply scans your `public/` directories (including of your layers) for font files (supporting `ttf`, `woff`, `woff2`, `eot` or `otf` extensions).
 
-Then, when you use a `font-family` in your CSS, we check to see whether it matches one of these files. We also expect font weight, font style and subset to be in the file name, unless they are 'default' values (`400` weight, `normal` style and `latin` subset).
+Then, when you use a `font-family` in your CSS, we check to see whether it matches one of these files. By default, we expect the font file to be the `400` weight, `normal` style, and `latin` subset. To indicate different weights and styles, please include that information in the filename. For example `comic-sans-ms.woff2` (400/normal/latin; defaults), `comic-sans-ms-700-italic-cyrillic.woff2` (700/italic/cyrillic). `font-family` values with spaces and/or caps will lookup hyphenated lowercase filenames as well.
+
 
 ### `google`
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #397

### ❓ Type of change

- [X] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I found myself struggling to understand what my local filenames were supposed to be called for the module to properly read them. Hopefully this small tweak makes it a tad more obvious how to structure the filenames. 
