### PR TITLE
docs: Callout limited default font-weights

### DIFF
--- a/docs/content/1.get-started/1.installation.md
+++ b/docs/content/1.get-started/1.installation.md
@@ -63,6 +63,10 @@ div {
 
 That's it! Nuxt Fonts will detect this and you should immediately see the web font loaded in your browser. [Read more about how it works](/advanced#how-it-works).
 
+::callout{icon="i-heroicons-exclamation-triangle" color="amber"}
+To improve performance, `@nuxt/fonts` by default only loads the normal/400 font-weight. See the [configuration docs](/get-started/configuration#styles) on how to change this default.
+::
+
 ::callout
 Check out the [configuration docs](/get-started/configuration) for all available options and features to customize.
 ::
@@ -98,3 +102,5 @@ If an error occurs during installation:
 - Check your network connection. Your machine might be having a hard time communicating with the font providers.
 
 - If none of the above worked, please [open an issue](https://github.com/nuxt/fonts/issues) and include the error trace, OS, Node version and the package manager used for installing.
+
+- If you're missing certain fonts or their variations, please confirm the module is [configured to load](/get-started/configuration#styles) the fonts you expected to see.

--- a/docs/content/1.get-started/2.configuration.md
+++ b/docs/content/1.get-started/2.configuration.md
@@ -45,6 +45,12 @@ export default defineNuxtConfig({
 })
 ```
 
+#### `weights`
+
+Default: `[400]`
+
+Defines the font-weights that should be downloaded for a font.
+
 #### `styles`
 
 Default: `['normal', 'italic']`


### PR DESCRIPTION
### 🔗 Linked issue

Ref https://github.com/nuxt/fonts/issues/209#issuecomment-2496066476

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

For a new user, it's not immediately obvious that only the 400 font weight is loaded for fonts. This PR aims to improve that by calling it out during the installation and troubleshooting steps.