### PR TITLE
chore: Fix bumpType default in changelog script

### DIFF
--- a/scripts/update-changelog.ts
+++ b/scripts/update-changelog.ts
@@ -13,7 +13,7 @@ async function main() {
   const commits = await getLatestCommits().then(commits => commits.filter(
     c => config.types[c.type] && !(c.type === 'chore' && c.scope === 'deps' && !c.isBreaking),
   ))
-  const bumpType = await determineBumpType() || 'patch'
+  const bumpType = (await determineBumpType()) || 'patch'
 
   const newVersion = inc(workspace.find('@nuxt/fonts').data.version, bumpType)
   const changelog = await generateMarkDown(commits, config)

--- a/scripts/update-changelog.ts
+++ b/scripts/update-changelog.ts
@@ -13,9 +13,9 @@ async function main() {
   const commits = await getLatestCommits().then(commits => commits.filter(
     c => config.types[c.type] && !(c.type === 'chore' && c.scope === 'deps' && !c.isBreaking),
   ))
-  const bumpType = await determineBumpType()
+  const bumpType = await determineBumpType() || 'patch'
 
-  const newVersion = inc(workspace.find('@nuxt/fonts').data.version, bumpType || 'patch')
+  const newVersion = inc(workspace.find('@nuxt/fonts').data.version, bumpType)
   const changelog = await generateMarkDown(commits, config)
 
   // Create and push a branch with bumped versions if it has not already been created


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #401

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `bumpType` can be `null`. `newVersion` defaults it to `patch`, but the rendered message doesn't default it in the same way. This tweak makes sure that both default to `patch` in the same way.