### PR TITLE
fix: Don't broadcast font if it has already been loaded prior

### DIFF
--- a/client/app.vue
+++ b/client/app.vue
@@ -17,7 +17,7 @@ const filtered = computed(() => fonts.value.filter(font => font.fontFamily.toLow
 onDevtoolsClientConnected(async (client) => {
   const rpc = client.devtools.extendClientRpc<ServerFunctions, ClientFunctions>(DEVTOOLS_RPC_NAMESPACE, {
     exposeFonts(newFonts) {
-      fonts.value.push(...newFonts)
+      fonts.value = removeDuplicates(newFonts)
     },
   })
 

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
-import { addCustomTab, extendServerRpc, onDevToolsInitialized } from '@nuxt/devtools-kit'
 import { createResolver, useNuxt } from '@nuxt/kit'
+import { addCustomTab, extendServerRpc, onDevToolsInitialized } from '@nuxt/devtools-kit'
 import type { BirpcGroup } from 'birpc'
 
 import { DEVTOOLS_RPC_NAMESPACE, DEVTOOLS_UI_PATH, DEVTOOLS_UI_PORT } from './constants'
@@ -81,13 +81,8 @@ export function setupDevtoolsConnection(enabled: boolean) {
     rpc.broadcast.exposeFonts.asEvent(fonts)
   })
   function exposeFonts(font: ManualFontDetails | ProviderFontDetails) {
-    if (!fontExists(font)) {
-      rpc?.broadcast.exposeFonts.asEvent([font])
-      fonts.push(font)
-    }
-  }
-  function fontExists(font: ManualFontDetails | ProviderFontDetails) {
-    return fonts.some(existing => existing.fontFamily === font.fontFamily && existing.type === font.type && existing.fonts.length === font.fonts.length)
+    fonts.push(font)
+    rpc?.broadcast.exposeFonts.asEvent(fonts)
   }
   return {
     exposeFont: exposeFonts,

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
-import { createResolver, useNuxt } from '@nuxt/kit'
 import { addCustomTab, extendServerRpc, onDevToolsInitialized } from '@nuxt/devtools-kit'
+import { createResolver, useNuxt } from '@nuxt/kit'
 import type { BirpcGroup } from 'birpc'
 
 import { DEVTOOLS_RPC_NAMESPACE, DEVTOOLS_UI_PATH, DEVTOOLS_UI_PORT } from './constants'
@@ -81,8 +81,13 @@ export function setupDevtoolsConnection(enabled: boolean) {
     rpc.broadcast.exposeFonts.asEvent(fonts)
   })
   function exposeFonts(font: ManualFontDetails | ProviderFontDetails) {
-    rpc?.broadcast.exposeFonts.asEvent([font])
-    fonts.push(font)
+    if (!fontExists(font)) {
+      rpc?.broadcast.exposeFonts.asEvent([font])
+      fonts.push(font)
+    }
+  }
+  function fontExists(font: ManualFontDetails | ProviderFontDetails) {
+    return fonts.some(existing => existing.fontFamily === font.fontFamily && existing.type === font.type && existing.fonts.length === font.fonts.length)
   }
   return {
     exposeFont: exposeFonts,


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #400

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When HMR runs, fonts are re-broadcasted even if they were already broadcasted prior; this results in fonts being shown in the DevTools continuously

---

### Reviewer Notes:

- I'm not entirely sure what the data flow is between module and DevTools (this is my first foray into Nuxt module/devtools), so lemme know if this is a dirty hack rather than a workable fix
- I didn't see any tests for the devtools.ts file, so lemme know if that's somewhere I didn't spot! 🙂 