### PR TITLE
docs: clarify that local provider does not load weights and styles as available automatically

### DIFF
--- a/docs/content/1.get-started/4.providers.md
+++ b/docs/content/1.get-started/4.providers.md
@@ -13,6 +13,9 @@ The local provider deeply scans your `public/` directories (including of your la
 
 Then, when you use a `font-family` in your CSS, we check to see whether it matches one of these files. By default, we expect the font file to be the `400` weight, `normal` style, and `latin` subset. To indicate different weights and styles, please include that information in the filename. For example `comic-sans-ms.woff2` (400/normal/latin; defaults), `comic-sans-ms-700-italic-cyrillic.woff2` (700/italic/cyrillic). Keywords like `light`, `bold`, or `black` are accepted in place of a weight number: `comic-sans-ms-bold.woff2`. `font-family` values with spaces and/or caps will lookup hyphenated lowercase filenames as well, eg `font-family: 'Comic Sans MS'` will look for `comic-sans-ms.woff2` as well as `Comic\ Sans\ MS.woff2` on disk.
 
+::callout{type=warning}
+Please note that the local provider will only attempt to load styles and weights that were configured in the [Font Options](./2.configuration.md#font-options).
+::
 
 ### `google`
 


### PR DESCRIPTION
### 🔗 Linked issue

There is no open issue, I hope that's okay for such a small doc change :innocent: 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a clarification to the docs that the local provider does not simply load available font weights and styles. They have to be configured first.  

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
