### PR TITLE
fix: terminate the build process when font resolution fails

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -212,8 +212,7 @@ export default defineNuxtModule<ModuleOptions>({
           // Rewrite font source URLs to be proxied/local URLs
           const fonts = normalizeFontData(result?.fonts || [])
           if (!fonts.length || !result) {
-            logger.warn(`Could not produce font face declaration from \`${override.provider}\` for font family \`${fontFamily}\`.`)
-            return
+            throw new Error(`Could not produce font face declaration from \`${override.provider}\` for font family \`${fontFamily}\`.`)
           }
           const fontsWithLocalFallbacks = addFallbacks(fontFamily, fonts)
           exposeFont({
@@ -251,7 +250,7 @@ export default defineNuxtModule<ModuleOptions>({
           }
         }
         if (override) {
-          logger.warn(`Could not produce font face declaration for \`${fontFamily}\` with override.`)
+          throw new Error(`Could not produce font face declaration for \`${fontFamily}\` with override.`)
         }
       }
     }


### PR DESCRIPTION
### 🔗 Linked issue
resolves #356

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This will ensure that the build process is terminated when the font face declarations cannot be produced, preventing a project with broken fonts from being deployed.

---

I'm wondering if this should be addressed upstream in `unifont` as well.
https://github.com/unjs/unifont/blob/f4d3efae764b78ab4c11cf303e465ecf5b95c1a4/src/index.ts#L55-L57
https://github.com/unjs/unifont/blob/f4d3efae764b78ab4c11cf303e465ecf5b95c1a4/src/index.ts#L79-L81

However, that would likely require a major version bump since it would be a breaking change. Then again, it might not be necessary, as one could simply check the return value to determine whether the resolution was successful.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
