### PR TITLE
fix: hash cached font file name

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -36,7 +36,7 @@ export async function setupPublicAssetStrategy(options: ModuleOptions['assets'] 
             const _url = source.url.replace(/\?.*/, '')
             const file = [
               // TODO: investigate why negative ignore pattern below is being ignored
-              (filename(_url) || _url).replace(/^-+/, ''),
+              hash(filename(_url) || _url).replace(/^-+/, ''),
               hash(source).replace(/-/, '_') + (extname(source.url) || formatToExtension(source.format) || ''),
             ].filter(Boolean).join('-')
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves #565

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When downloading a font file with a very long name, an `ENAMETOOLONG` error is thrown. This change fixes this by ensuring that the file name is kept in check.

Example URL From Google:
> https://fonts.gstatic.com/s/robotoflex/v27/NaN4epOXO_NexZs0b5QrzlOHb8wCikXpYqmZsWI-__OGbt8jZktqc2V3Zs0KvDLdBP8SBZtOs2IifRuUZQMsPJtUsR4DEK6cULNeUx9XgTnH37Ha_FIAp4Fm0PP1hw45DntW2x0wZGzhPmr1YNMYKYn9_1IQXGwJAiUJVUMdN5YUW4O8HtSoXjC1z3QSabshNFVe3e0O5j3ZjrZCu23Qd4G0EBysQNK-QKavMl12K4Uc5-TkjOSy.woff2

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
