### PR TITLE
fix: prevent ENAMETOOLONG for long Google Font URLs

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -34,9 +34,10 @@ export async function setupPublicAssetStrategy(options: ModuleOptions['assets'] 
           if ('url' in source && hasProtocol(source.url, { acceptRelative: true })) {
             source.url = source.url.replace(/^\/\//, 'https://')
             const _url = source.url.replace(/\?.*/, '')
+            const MAX_FILENAME_PREFIX_LENGTH = 50
             const file = [
               // TODO: investigate why negative ignore pattern below is being ignored
-              hash(filename(_url) || _url).replace(/^-+/, ''),
+              hash(filename(_url) || _url).replace(/^-+/, '').slice(0, MAX_FILENAME_PREFIX_LENGTH),
               hash(source).replace(/-/, '_') + (extname(source.url) || formatToExtension(source.format) || ''),
             ].filter(Boolean).join('-')
 


### PR DESCRIPTION
This prevents "Nuxt Build Error: [nuxt:fonts:font-family-injection] ENAMETOOLONG: name too long" for long Google Fonts file names

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

This PR addresses an ENAMETOOLONG error that can occur during the build process when using @nuxt/fonts with variable fonts fetched from providers like Google Fonts (e.g., Roboto Flex).
The error arises because the current cache filename generation logic in setupPublicAssetStrategy includes a potentially very long identifier derived from the original font URL. In projects with deeper directory structures, the combination of the base path, the .nuxt/cache/fonts path, and this long filename prefix can exceed filesystem path length limits, causing the build to fail.
This change resolves the issue by truncating the URL-derived portion of the cache filename to a maximum of 50 characters. This significantly reduces the overall path length, preventing the error while still retaining some context from the original URL. The existing hash component of the filename ensures cache uniqueness remains intact.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
