### PR TITLE
docs: use tailwind v3 url

### DIFF
--- a/docs/content/1.get-started/3.usage.md
+++ b/docs/content/1.get-started/3.usage.md
@@ -34,7 +34,7 @@ export default {
 ```
 
 ::callout
-If the font name contains an invalid identifier (like a space character), you'll need to wrap it in quotes or escape the character manually. Read more [here](https://tailwindcss.com/docs/font-family#customizing-your-theme).
+If the font name contains an invalid identifier (like a space character), you'll need to wrap it in quotes or escape the character manually. Read more [here](https://v3.tailwindcss.com/docs/font-family#customizing-your-theme).
 ::
 
 ### v4


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ x ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
The callout for wrapping invalid font identifiers in spaces links to [tailwind v4 docs](https://tailwindcss.com/docs/font-family#customizing-your-theme). This PR updates that URL to link to [tailwind v3 docs](https://v3.tailwindcss.com/docs/font-family#customizing-your-theme) as the proper description is provided there
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
