### PR TITLE
fix: deduplicate defaults

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -112,9 +112,9 @@ export default defineNuxtModule<ModuleOptions>({
     // Custom merging for defaults - providing a value for any default will override module
     // defaults entirely (to prevent array merging)
     const normalizedDefaults = {
-      weights: (options.defaults?.weights || defaultValues.weights).map(v => String(v)),
-      styles: options.defaults?.styles || defaultValues.styles,
-      subsets: options.defaults?.subsets || defaultValues.subsets,
+      weights: [...new Set((options.defaults?.weights || defaultValues.weights).map(v => String(v)))],
+      styles: [...new Set(options.defaults?.styles || defaultValues.styles)],
+      subsets: [...new Set(options.defaults?.subsets || defaultValues.subsets)],
       fallbacks: Object.fromEntries(Object.entries(defaultValues.fallbacks).map(([key, value]) => [
         key,
         Array.isArray(options.defaults?.fallbacks) ? options.defaults.fallbacks : options.defaults?.fallbacks?.[key as GenericCSSFamily] || value,


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

With layers, default options might get duplicated which breaks the font detection.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
