### PR TITLE
Bugfix/self signed certs dev

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -17,7 +17,6 @@ import { storage } from './cache'
 import { logger } from './logger'
 import type { ModuleOptions, fetchType } from './types'
 
-
 // TODO: replace this with nuxt/assets when it is released
 export async function setupPublicAssetStrategy(options: ModuleOptions['assets'] = {}) {
   const nuxt = useNuxt()
@@ -39,9 +38,9 @@ export async function setupPublicAssetStrategy(options: ModuleOptions['assets'] 
     // Use storage to cache the font data between requests
     let res = await storage.getItemRaw(key)
     if (!res) {
-      const fetch = nativeFetch as unknown as fetchType;
-      const proxy = createProxy();
-      const insecureAgent = import.meta.dev ? new HttpsAgent({ rejectUnauthorized: false }) : undefined;
+      const fetch = nativeFetch as unknown as fetchType
+      const proxy = createProxy()
+      const insecureAgent = import.meta.dev ? new HttpsAgent({ rejectUnauthorized: false }) : undefined
       const fetchOpts = {
         agent: insecureAgent ?? proxy.agent,
         dispatcher: proxy.dispatcher,

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,3 +45,9 @@ export interface FontProvider<FontProviderOptions = Record<string, unknown>> {
 export interface ModuleHooks {
   'fonts:providers': (providers: Record<string, ProviderFactory | FontProvider>) => void | Promise<void>
 }
+
+export type fetchType = (input: string, init?: {
+  agent?: unknown
+  dispatcher?: unknown
+  [key: string]: any
+}) => Promise<Response>

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,5 +49,4 @@ export interface ModuleHooks {
 export type fetchType = (input: string, init?: {
   agent?: unknown
   dispatcher?: unknown
-  [key: string]: any
 }) => Promise<Response>


### PR DESCRIPTION
### 🐛 Problem

Since upgrading to Nuxt 4, when running nuxt dev against a local back‑end over HTTPS with a self‑signed certificate, the built‑in font proxy in src/assets.ts does a plain fetch(url) (via node-fetch-native/proxy), which rejects the cert and leads to ETIMEDOUT / TLS errors.

```
ERROR  [request error] [unhandled] [GET] https://localhost:3000/_app/_fonts/Jtqhy44WKYEjGWTSusP5YJfJv7Wf74QqgkBOI9u_77s-APe4uUTMgFlx0lDK_9ElYfqG-yZoHhecemR9pVMDVfs.woff
 
ℹ Error: fetch failed

 ⁃ (node:internal/deps/undici/undici:13510:13)
 ⁃ at processTicksAndRejections (node:internal/process/task_queues:95:5)
 ⁃ at runNextTicks (node:internal/process/task_queues:64:3)
 ⁃ at process.processTimers (node:internal/timers:516:9)
 ⁃ at async Object.devEventHandler [as handler] (node_modules/.pnpm/@nuxt+fonts@0.11.4_@netlify+blobs@9.1.2_db0@0.3.2_ioredis@5.6.1_magicast@0.3.5_vite@7.0_49c86b5204f6dd180553088712d6b861/node_modules/@nuxt/fonts/dist/module.mjs:577:13)

   572 ┃        throw createError({ statusCode: 404 });
   573 ┃      }
   574 ┃      const key = "data:fonts:" + filename2;
   575 ┃      let res = await storage.getItemRaw(key);
   576 ┃      if (!res) {
 ❯ 577 ┃        res = await fetch(url).then((r) => r.arrayBuffer()).then((r) => Buffer.from(r));
   578 ┃        await storage.setItemRaw(key, res);
   579 ┃      }
   580 ┃      return res;
   581 ┃    }
   582 ┃    addDevServerHandler({

 ⁃ at async Object.handler (node_modules/.pnpm/h3@1.15.3/node_modules/h3/dist/index.mjs:2003:19)
 ⁃ at async NuxtDevServer.toNodeHandle [as _handler] (node_modules/.pnpm/h3@1.15.3/node_modules/h3/dist/index.mjs:2295:7)

[CAUSE]
AggregateError {
  stack: '\n' +
  '    at internalConnectMultiple (node:net:1122:18)\n' +
  '    at internalConnectMultiple (node:net:1190:5)\n' +
  '    at Timeout.internalConnectMultipleTimeout (node:net:1716:5)\n' +
  '    at listOnTimeout (node:internal/timers:583:11)\n' +
  '    at process.processTimers (node:internal/timers:519:7)',
  errors: [
    [Object],
    [Object],
  ],
  code: 'ETIMEDOUT',
}
```


### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Added a dev-only HTTPS agent (rejectUnauthorized: false) to the font proxy fetch in src/assets.ts, so fonts can load from local HTTPS servers with self-signed certs. This change is required because since Nuxt 4, the dev font proxy fetch fails on self-signed certificates, leading to timeouts and TLS errors, and previously required setting NODE_TLS_REJECT_UNAUTHORIZED=0 globally (which is insecure). With this fix, fonts load correctly in nuxt dev without disabling TLS globally or affecting production.