### PR TITLE
docs: add Installation section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Plug-and-play custom web font optimization and configuration for Nuxt apps.
 
 👉 See [Nuxt Fonts RFC](https://github.com/nuxt/nuxt/discussions/22014) for full details and discussion.
 
+### Installation
+
+Install `@nuxt/fonts` dependency to your project:
+
+```sh
+npx nuxi module add fonts
+```
+
 ### Contributing
 
 - Clone this repository


### PR DESCRIPTION
### 🔗 Linked issue

n/a

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I find it more convienent having a section on the nuxt module / README that tells us how we can install the package so we don't have to click another link to find out how to install ithe module.
https://nuxt.com/modules/fonts

This is also consistent with other offical nuxt modules that have an Installation section in the README.
- https://nuxt.com/modules/seo#installation
- https://nuxt.com/modules/icon#setup-%EF%B8%8F
- https://nuxt.com/modules/i18n#install
- https://nuxt.com/modules/ui#installation
