### PR TITLE
perf: initialise providers in parallel with nuxt setup

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -83,9 +83,6 @@ export default defineNuxtModule<ModuleOptions>({
       }
 
       resolvePromise = createResolver({ options, logger, providers, storage, exposeFont, normalizeFontData })
-        .then((r) => {
-          return resolveFontFaceWithOverride = r
-        })
     })
 
     nuxt.options.css.push('#build/nuxt-fonts-global.css')
@@ -93,9 +90,7 @@ export default defineNuxtModule<ModuleOptions>({
       filename: 'nuxt-fonts-global.css',
       write: true, // Seemingly necessary to allow vite to process file 🤔
       async getContents() {
-        if (!resolveFontFaceWithOverride) {
-          await resolvePromise
-        }
+        resolveFontFaceWithOverride ||= await resolvePromise
         let css = ''
         for (const family of options.families || []) {
           if (!family.global) continue

--- a/src/module.ts
+++ b/src/module.ts
@@ -63,15 +63,17 @@ export default defineNuxtModule<ModuleOptions>({
       }
     }
 
-    const providers = await resolveProviders(options.providers, { root: nuxt.options.rootDir, alias: nuxt.options.alias })
+    const _providers = resolveProviders(options.providers, { root: nuxt.options.rootDir, alias: nuxt.options.alias })
 
     const { normalizeFontData } = await setupPublicAssetStrategy(options.assets)
     const { exposeFont } = setupDevtoolsConnection(nuxt.options.dev && !!options.devtools)
 
     let resolveFontFaceWithOverride: Resolver
+    let resolvePromise: Promise<Resolver>
 
     // Allow registering and disabling providers
     nuxt.hook('modules:done', async () => {
+      const providers = await _providers
       await nuxt.callHook('fonts:providers', providers)
       for (const key in providers) {
         const provider = providers[key]
@@ -80,14 +82,10 @@ export default defineNuxtModule<ModuleOptions>({
         }
       }
 
-      resolveFontFaceWithOverride = await createResolver({
-        options,
-        logger,
-        providers,
-        storage,
-        exposeFont,
-        normalizeFontData,
-      })
+      resolvePromise = createResolver({ options, logger, providers, storage, exposeFont, normalizeFontData })
+        .then((r) => {
+          return resolveFontFaceWithOverride = r
+        })
     })
 
     nuxt.options.css.push('#build/nuxt-fonts-global.css')
@@ -95,6 +93,9 @@ export default defineNuxtModule<ModuleOptions>({
       filename: 'nuxt-fonts-global.css',
       write: true, // Seemingly necessary to allow vite to process file 🤔
       async getContents() {
+        if (!resolveFontFaceWithOverride) {
+          await resolvePromise
+        }
         let css = ''
         for (const family of options.families || []) {
           if (!family.global) continue


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

this addresses a performance issue in which all font providers initialise in `modules:done`, blocking the vite build.

instead, we initiate the font provider setup at the same point, in a non-blocking manner, and wait only when it's required