### PR TITLE
test: add test for css variable processing

### DIFF
--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -56,7 +56,7 @@ describe('parsing', () => {
           line-gap-override: 8.125%;
         }
 
-        :root { --font-display: 'Poppins', "Poppins Fallback: Times New Roman", "Poppins Fallback: sans-serif", sans-serif; }"
+        :root { --font-display: 'Poppins', "Poppins Fallback: Times New Roman", sans-serif; }"
       `)
   })
 
@@ -68,7 +68,7 @@ describe('parsing', () => {
           src: url("/poppins.woff2") format(woff2);
           font-display: swap;
         }
-        :root { --font-heading: POPPINS, "POPPINS Fallback: Times New Roman", "POPPINS Fallback: serif", serif; }"
+        :root { --font-heading: POPPINS, serif; }"
       `)
   })
 
@@ -89,7 +89,7 @@ describe('parsing', () => {
           line-gap-override: 8.125%;
         }
 
-        :root { --font-a: 'Poppins', "Poppins Fallback: Times New Roman", "Poppins Fallback: sans-serif", sans-serif; --font-b: 'Poppins', serif; }"
+        :root { --font-a: 'Poppins', "Poppins Fallback: Times New Roman", sans-serif; --font-b: 'Poppins', "Poppins Fallback: Times New Roman", serif; }"
       `)
   })
 
@@ -110,7 +110,16 @@ describe('parsing', () => {
           line-gap-override: 8.125%;
         }
 
-        :root { --font-body: 'Poppins', "Poppins Fallback: Times New Roman", "Poppins Fallback: Arial", "Poppins Fallback: sans-serif", Arial, sans-serif; }"
+        @font-face {
+          font-family: "Poppins Fallback: Arial";
+          src: local("Arial");
+          size-adjust: 112.1577%;
+          ascent-override: 93.6182%;
+          descent-override: 31.2061%;
+          line-gap-override: 8.916%;
+        }
+
+        :root { --font-body: 'Poppins', "Poppins Fallback: Times New Roman", "Poppins Fallback: Arial", Arial, sans-serif; }"
       `)
   })
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Process CSS variables containing font stacks to insert generated fallback fonts.

This handles Tailwind 4's @theme variables like: --font-body: 'Noto Serif SC', Georgia, serif;

Closes https://github.com/nuxt/fonts/issues/706
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
