### PR TITLE
fix: pass a real H3Event in Storybook mode

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -2,7 +2,7 @@ import fsp from 'node:fs/promises'
 import { writeFileSync } from 'node:fs'
 import { addDevServerHandler, addVitePlugin, useNuxt } from '@nuxt/kit'
 import type { H3Event } from 'h3'
-import { eventHandler, createError, setResponseHeader } from 'h3'
+import { eventHandler, createEvent, createError, setResponseHeader } from 'h3'
 import { $fetch } from 'ofetch'
 import { colors } from 'consola/utils'
 import { defu } from 'defu'
@@ -58,7 +58,10 @@ export async function setupPublicAssetStrategy(options: ModuleOptions['assets'] 
       if (server.config.appType !== 'custom' || nuxt.options.buildId === 'storybook') {
         server.middlewares.use(
           context.assetsBaseURL,
-          async (req, res) => { res.end(await devEventHandler({ path: req.url } as H3Event)) },
+          async (req, res) => {
+            const h3evt = createEvent(req, res)
+            res.end(await devEventHandler(h3evt))
+          },
         )
       }
     },


### PR DESCRIPTION
### 🔗 Linked issue

Drive-by PR without a linked issue 🫣

### 📚 Description

Restores Storybook compatibility. h3 was trying to set the cache header, but the injected handler in Storybook mode did not pass the req/res objects. This was crashing the Storybook server on start as soon as a font was loaded.

Regression introduced in 0ec437e7732e15cfe3f4b7466dbfc9de1f99cb78.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
