### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,21 +90,5 @@
     "vue-bundle-renderer": "^2.2.0",
     "vue-tsc": "^3.2.8"
   },
-  "packageManager": "pnpm@10.33.4",
-  "pnpm": {
-    "ignoredBuiltDependencies": [
-      "@parcel/watcher",
-      "esbuild",
-      "unrs-resolver",
-      "vue-demi"
-    ],
-    "onlyBuiltDependencies": [
-      "@tailwindcss/oxide",
-      "better-sqlite3",
-      "sharp"
-    ],
-    "patchedDependencies": {
-      "@nuxt/devtools-ui-kit": "patches/@nuxt__devtools-ui-kit.patch"
-    }
-  }
+  "packageManager": "pnpm@11.1.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,3 +18,15 @@ overrides:
   typescript: ^6.0.3
   unocss: ^66.6.8
   vite: ~7.3.3
+
+patchedDependencies:
+  "@nuxt/devtools-ui-kit": patches/@nuxt__devtools-ui-kit.patch
+
+allowBuilds:
+  "@parcel/watcher": false
+  "@tailwindcss/oxide": true
+  better-sqlite3: true
+  esbuild: false
+  sharp: true
+  unrs-resolver: false
+  vue-demi: false


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`