### PR TITLE
test: refresh snapshots + make resilient to vite 8 changes

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,7 +171,7 @@ importers:
         version: 3.5.38(typescript@6.0.3)
       vue-router:
         specifier: latest
-        version: 5.1.0(@vue/compiler-sfc@3.5.38)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+        version: 5.2.0(@vue/compiler-sfc@3.5.38)(esbuild@0.28.0)(rollup@4.60.3)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))(webpack@5.104.1(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
 
   docs:
     dependencies:
@@ -180,7 +180,7 @@ importers:
         version: link:..
       '@nuxt/ui':
         specifier: ^4.9.0
-        version: 4.9.0(cdf7f913baffef1415b965ede15f77b9)
+        version: 4.9.0(c675a9243add3d1e430d52449963d879)
       '@nuxtjs/plausible':
         specifier: 3.0.2
         version: 3.0.2(magicast@0.5.3)
@@ -189,7 +189,7 @@ importers:
         version: 12.11.1
       docus:
         specifier: ^5.12.2
-        version: 5.12.2(d965c33aaf240e1bbdb0e01667835ca4)
+        version: 5.12.2(fc918853fda01bf89d227f56429bc2b3)
       tailwindcss:
         specifier: ^4.3.1
         version: 4.3.1
@@ -216,7 +216,7 @@ importers:
         version: 3.5.38(typescript@6.0.3)
       vue-router:
         specifier: latest
-        version: 5.1.0(@vue/compiler-sfc@3.5.38)(vite@7.3.5(@types/node@24.13.2)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+        version: 5.2.0(@vue/compiler-sfc@3.5.38)(esbuild@0.28.0)(rollup@4.60.3)(vite@7.3.5(@types/node@24.13.2)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))(webpack@5.104.1(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
 
   playgrounds/scss:
     dependencies:
@@ -231,7 +231,7 @@ importers:
         version: 3.5.38(typescript@6.0.3)
       vue-router:
         specifier: latest
-        version: 5.1.0(@vue/compiler-sfc@3.5.38)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+        version: 5.2.0(@vue/compiler-sfc@3.5.38)(esbuild@0.28.0)(rollup@4.60.3)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))(webpack@5.104.1(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
     devDependencies:
       sass:
         specifier: ^1.101.0
@@ -256,7 +256,7 @@ importers:
         version: 3.5.38(typescript@6.0.3)
       vue-router:
         specifier: latest
-        version: 5.1.0(@vue/compiler-sfc@3.5.38)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+        version: 5.2.0(@vue/compiler-sfc@3.5.38)(esbuild@0.28.0)(rollup@4.60.3)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))(webpack@5.104.1(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
 
   playgrounds/tailwindcss@4:
     dependencies:
@@ -277,7 +277,7 @@ importers:
         version: 3.5.38(typescript@6.0.3)
       vue-router:
         specifier: latest
-        version: 5.1.0(@vue/compiler-sfc@3.5.38)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+        version: 5.2.0(@vue/compiler-sfc@3.5.38)(esbuild@0.28.0)(rollup@4.60.3)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))(webpack@5.104.1(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
 
   playgrounds/unocss:
     dependencies:
@@ -298,7 +298,7 @@ importers:
         version: 3.5.38(typescript@6.0.3)
       vue-router:
         specifier: latest
-        version: 5.1.0(@vue/compiler-sfc@3.5.38)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+        version: 5.2.0(@vue/compiler-sfc@3.5.38)(esbuild@0.28.0)(rollup@4.60.3)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))(webpack@5.104.1(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
 
 packages:
 
@@ -359,6 +359,10 @@ packages:
     resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/generator@8.0.0':
+    resolution: {integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/generator@8.0.0-rc.5':
     resolution: {integrity: sha512-nFZPWz3FHIS7y6rMIVoa/WBwjdutfIaRJIBQjzn+t3RnecZoRNlGmGcyR2wb0T/IgSd50Kz/6dG8/LvMCRunjg==}
     engines: {node: ^22.18.0 || >=24.11.0}
@@ -417,6 +421,10 @@ packages:
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@8.0.0':
+    resolution: {integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-string-parser@8.0.0-rc.5':
     resolution: {integrity: sha512-sN7R8rBvDurfaziNfDEIjIntlazmlkCDGO4SNl2RJ3wRCn+QxspLV7hzYAE8WWVd2joVuT8sUxeePdLp2idI1A==}
     engines: {node: ^22.18.0 || >=24.11.0}
@@ -427,6 +435,10 @@ packages:
 
   '@babel/helper-validator-identifier@8.0.0-rc.5':
     resolution: {integrity: sha512-ehJDxHvtbZ85RtX/L2fi0h9AGsBNqB5Euv1EB8RMAvGYvD+2X+QbpzzOpbklnNXO+WSZJNOaetw2BBj27xsWVg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-validator-identifier@8.0.4':
+    resolution: {integrity: sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-validator-option@7.27.1':
@@ -444,6 +456,11 @@ packages:
 
   '@babel/parser@8.0.0-rc.5':
     resolution: {integrity: sha512-/Mfg83rK3+jsRbl4Vbd0jqxc6M1A1/WNFtgrowRM1unEsD3XcNnrBdMM0JWakd0/RN9lseQKwPduW1TiEwKOlQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    hasBin: true
+
+  '@babel/parser@8.0.4':
+    resolution: {integrity: sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==}
     engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
 
@@ -479,6 +496,10 @@ packages:
 
   '@babel/types@8.0.0-rc.5':
     resolution: {integrity: sha512-JeSVu/m8x/zpp4CLjYHVNXuhEyOkhPXuxM8YOXjh6L4LlvQNKuUNOTo5KdBuKAcTDHw8DquToTaEkhsBqPXOaA==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/types@8.0.4':
+    resolution: {integrity: sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
   '@bcoe/v8-coverage@1.0.2':
@@ -4024,6 +4045,15 @@ packages:
       vue:
         optional: true
 
+  '@vue-macros/common@3.1.3':
+    resolution: {integrity: sha512-pphnexn8CDKugcA4TYSKlg1XanBYPbILST+eZK9ZGqG8sVbNR5L0kXEpRqs8+iSznosHt/Jo2k1FGl0tnWIpyg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      vue: ^2.7.0 || ^3.2.25
+    peerDependenciesMeta:
+      vue:
+        optional: true
+
   '@vue/babel-helper-vue-transform-on@2.0.1':
     resolution: {integrity: sha512-uZ66EaFbnnZSYqYEyplWvn46GhZ1KuYSThdT68p+am7MgBNbQ3hphTL9L+xSIsWkdktwhPYLwPgVWqo96jDdRA==}
 
@@ -4058,6 +4088,9 @@ packages:
   '@vue/devtools-api@8.1.2':
     resolution: {integrity: sha512-vA0O112YqyDuNA1s7Yb2gCgToQ/OxOWiFDO5ThLCcDy0ldHnSd1dUTaSYhOldbqoNgumE4dxtGAoAaSUKUD1Zg==}
 
+  '@vue/devtools-api@8.1.5':
+    resolution: {integrity: sha512-YJipMVAKe5wT5CWf5kTYCaNV7NMNjFVxJkIkJaJ4W/nCxEBzlZzrOsYKeCymdCrFZmBS/+wTWFoUs3Jf/Q6XSQ==}
+
   '@vue/devtools-core@8.1.2':
     resolution: {integrity: sha512-ZGGyaSBP4/+bN2Nd9ZHNYAVDRIzMw1rv2RyXWtyZlo6mQal+IDmTvKY4V+DjAEBhaXt30mHmsgYp1yXJ/2tIWg==}
     peerDependencies:
@@ -4066,8 +4099,14 @@ packages:
   '@vue/devtools-kit@8.1.2':
     resolution: {integrity: sha512-f75/upc+GCyjXErpgPGz4582ujS0L/adAltGy+tqXMGUJpgAcfGr6CxnnhpZY8BHuMYt6KpbF8uaFrrQG66rGQ==}
 
+  '@vue/devtools-kit@8.1.5':
+    resolution: {integrity: sha512-FcSAxsi4eWuXLCB7Rv9lj0aIVHHPNVQ2BazGf4RJTc2JCqb4BQg0hk87ZFhminCfl+mD5OUI0rX2cgyu4kJOGA==}
+
   '@vue/devtools-shared@8.1.2':
     resolution: {integrity: sha512-X9RyVFYAdkBe4IUf5v48TxBF/6QPmF8CmWrDAjXzfUHrgQ/HGfTC1A6TqgXqZ03ye66l3AD51BAGD69IvKM9sw==}
+
+  '@vue/devtools-shared@8.1.5':
+    resolution: {integrity: sha512-mhT4zcPFhF+Xk1O4BfhhrbXzpmfqY03fS6xGpcllbQG7lDjhQf8pQHcTIhqQIYx1hfwtHmk/6jM96ele0UxPqQ==}
 
   '@vue/language-core@3.2.2':
     resolution: {integrity: sha512-5DAuhxsxBN9kbriklh3Q5AMaJhyOCNiQJvCskN9/30XOpdLiqZU9Q+WvjArP17ubdGEyZtBzlIeG5nIjEbNOrQ==}
@@ -6740,6 +6779,9 @@ packages:
   nostics@0.2.0:
     resolution: {integrity: sha512-/WQpI46UMbqvy1okYb+V+9wW3J8/m6GJ33wm691n/tyi6YtJiZ6ssJjENAU7y4evfYrrgYN9HllKDzPvffil1w==}
 
+  nostics@1.1.4:
+    resolution: {integrity: sha512-U4FApICSLCQ0dYiN59pxUCEZC053palQXi57yLaNdMaL6TBY4C4q3qZrJKUGcor2dGv8EhEwt8y5KvU2bo2kFg==}
+
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -7072,6 +7114,10 @@ packages:
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
   pify@2.3.0:
@@ -8340,6 +8386,10 @@ packages:
     resolution: {integrity: sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==}
     engines: {node: '>=20.19.0'}
 
+  unplugin-utils@0.3.2:
+    resolution: {integrity: sha512-xVToRh2CTmLk2HnEG7ac4rl1MJTT3RFkpS8B++/SnB0kXvuaavD+n3m/vrzyWQOdJNSZQACnbz01pnppbwV5BA==}
+    engines: {node: '>=20.19.0'}
+
   unplugin-vue-components@32.1.0:
     resolution: {integrity: sha512-YiUkSxuRjab18XFOrX5VsIxXzccrfmHVGsGeJgSgklb829DQmCy9E4vvDUE4tuvZZdxyFJZX0Oc4TPnnxiiMyg==}
     engines: {node: '>=20.19.0'}
@@ -8367,6 +8417,39 @@ packages:
   unplugin@3.0.0:
     resolution: {integrity: sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==}
     engines: {node: ^20.19.0 || >=22.12.0}
+
+  unplugin@3.3.0:
+    resolution: {integrity: sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@farmfe/core': '*'
+      '@rspack/core': '*'
+      bun-types-no-globals: '*'
+      esbuild: '*'
+      rolldown: '*'
+      rollup: '*'
+      unloader: '*'
+      vite: ~7.3.5
+      webpack: '*'
+    peerDependenciesMeta:
+      '@farmfe/core':
+        optional: true
+      '@rspack/core':
+        optional: true
+      bun-types-no-globals:
+        optional: true
+      esbuild:
+        optional: true
+      rolldown:
+        optional: true
+      rollup:
+        optional: true
+      unloader:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
 
   unrouting@0.1.7:
     resolution: {integrity: sha512-+0hfD+CVWtD636rc5Fn9VEjjTEDhdqgMpbwAuVoUmydSHDaMNiFW93SJG4LV++RoGSEAyvQN5uABAscYpDphpQ==}
@@ -8732,6 +8815,24 @@ packages:
       vite:
         optional: true
 
+  vue-router@5.2.0:
+    resolution: {integrity: sha512-QAC5i0LEb1GLG0LXDQmHu8L7FX12j0KwU/JTKmLQUJMrn04gQdKP6Du+p0QwpHb3iy71vBlqnHQ8WAfOSAWhqw==}
+    peerDependencies:
+      '@pinia/colada': '>=0.21.2'
+      '@vue/compiler-sfc': ^3.5.34 || ^4.0.0
+      pinia: ^3.0.4 || ^4.0.2
+      vite: ~7.3.5
+      vue: ^3.5.34 || ^4.0.0
+    peerDependenciesMeta:
+      '@pinia/colada':
+        optional: true
+      '@vue/compiler-sfc':
+        optional: true
+      pinia:
+        optional: true
+      vite:
+        optional: true
+
   vue-sfc-transformer@0.1.17:
     resolution: {integrity: sha512-0mpkDTWm1ybtp/Mp3vhrXP4r8yxcGF+quxGyJfrHDl2tl5naQjK3xkIGaVR5BtR5KG1LWJbdCrqn7I6f460j9A==}
     engines: {node: '>=18.0.0'}
@@ -9050,6 +9151,15 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
+  '@babel/generator@8.0.0':
+    dependencies:
+      '@babel/parser': 8.0.4
+      '@babel/types': 8.0.4
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/jsesc': 2.5.1
+      jsesc: 3.1.0
+
   '@babel/generator@8.0.0-rc.5':
     dependencies:
       '@babel/parser': 8.0.0-rc.5
@@ -9133,11 +9243,15 @@ snapshots:
 
   '@babel/helper-string-parser@7.29.7': {}
 
+  '@babel/helper-string-parser@8.0.0': {}
+
   '@babel/helper-string-parser@8.0.0-rc.5': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-identifier@8.0.0-rc.5': {}
+
+  '@babel/helper-validator-identifier@8.0.4': {}
 
   '@babel/helper-validator-option@7.27.1': {}
 
@@ -9153,6 +9267,10 @@ snapshots:
   '@babel/parser@8.0.0-rc.5':
     dependencies:
       '@babel/types': 8.0.0-rc.5
+
+  '@babel/parser@8.0.4':
+    dependencies:
+      '@babel/types': 8.0.4
 
   '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -9202,6 +9320,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 8.0.0-rc.5
       '@babel/helper-validator-identifier': 8.0.0-rc.5
+
+  '@babel/types@8.0.4':
+    dependencies:
+      '@babel/helper-string-parser': 8.0.0
+      '@babel/helper-validator-identifier': 8.0.4
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -10652,7 +10775,7 @@ snapshots:
       - typescript
       - vite
 
-  '@nuxt/ui@4.9.0(cdf7f913baffef1415b965ede15f77b9)':
+  '@nuxt/ui@4.9.0(c675a9243add3d1e430d52449963d879)':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@iconify/vue': 5.0.1(vue@3.5.38(typescript@6.0.3))
@@ -10723,7 +10846,7 @@ snapshots:
       '@internationalized/number': 3.6.5
       '@nuxt/content': 3.14.0(@valibot/to-json-schema@1.7.0(valibot@1.4.1(typescript@6.0.3)))(better-sqlite3@12.11.1)(magicast@0.5.3)(valibot@1.4.1(typescript@6.0.3))
       valibot: 1.4.1(typescript@6.0.3)
-      vue-router: 5.1.0(@vue/compiler-sfc@3.5.38)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+      vue-router: 5.2.0(@vue/compiler-sfc@3.5.38)(esbuild@0.28.0)(rollup@4.60.3)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))(webpack@5.104.1(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       zod: 4.4.3
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
@@ -13049,6 +13172,16 @@ snapshots:
     optionalDependencies:
       vue: 3.5.38(typescript@6.0.3)
 
+  '@vue-macros/common@3.1.3(vue@3.5.38(typescript@6.0.3))':
+    dependencies:
+      '@vue/compiler-sfc': 3.5.38
+      ast-kit: 2.2.0
+      local-pkg: 1.2.1
+      magic-string-ast: 1.0.3
+      unplugin-utils: 0.3.1
+    optionalDependencies:
+      vue: 3.5.38(typescript@6.0.3)
+
   '@vue/babel-helper-vue-transform-on@2.0.1': {}
 
   '@vue/babel-plugin-jsx@2.0.1(@babel/core@7.29.0)':
@@ -13114,6 +13247,10 @@ snapshots:
     dependencies:
       '@vue/devtools-kit': 8.1.2
 
+  '@vue/devtools-api@8.1.5':
+    dependencies:
+      '@vue/devtools-kit': 8.1.5
+
   '@vue/devtools-core@8.1.2(vue@3.5.38(typescript@6.0.3))':
     dependencies:
       '@vue/devtools-kit': 8.1.2
@@ -13127,7 +13264,16 @@ snapshots:
       hookable: 5.5.3
       perfect-debounce: 2.1.0
 
+  '@vue/devtools-kit@8.1.5':
+    dependencies:
+      '@vue/devtools-shared': 8.1.5
+      birpc: 2.9.0
+      hookable: 5.5.3
+      perfect-debounce: 2.1.0
+
   '@vue/devtools-shared@8.1.2': {}
+
+  '@vue/devtools-shared@8.1.5': {}
 
   '@vue/language-core@3.2.2':
     dependencies:
@@ -14038,7 +14184,7 @@ snapshots:
 
   dlv@1.1.3: {}
 
-  docus@5.12.2(d965c33aaf240e1bbdb0e01667835ca4):
+  docus@5.12.2(fc918853fda01bf89d227f56429bc2b3):
     dependencies:
       '@ai-sdk/gateway': 3.0.133(zod@4.4.3)
       '@ai-sdk/mcp': 1.0.52(zod@4.4.3)
@@ -14050,7 +14196,7 @@ snapshots:
       '@nuxt/content': 3.14.0(@valibot/to-json-schema@1.7.0(valibot@1.4.1(typescript@6.0.3)))(better-sqlite3@12.11.1)(magicast@0.5.3)(valibot@1.4.1(typescript@6.0.3))
       '@nuxt/image': 2.0.0(db0@0.3.4(better-sqlite3@12.11.1))(ioredis@5.10.1)(magicast@0.5.3)
       '@nuxt/kit': 4.2.2(magicast@0.5.3)
-      '@nuxt/ui': 4.9.0(cdf7f913baffef1415b965ede15f77b9)
+      '@nuxt/ui': 4.9.0(c675a9243add3d1e430d52449963d879)
       '@nuxtjs/i18n': 10.4.0(@vue/compiler-dom@3.5.38)(db0@0.3.4(better-sqlite3@12.11.1))(eslint@10.5.0(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.3)(rollup@4.60.3)(typescript@6.0.3)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
       '@nuxtjs/mcp-toolkit': 0.17.2(@vue/compiler-sfc@3.5.38)(h3@1.15.11)(magicast@0.5.3)(rollup@4.60.3)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))(zod@4.4.3)
       '@nuxtjs/mdc': 0.22.0(magicast@0.5.3)
@@ -16528,6 +16674,8 @@ snapshots:
       oxc-parser: 0.132.0
       unplugin: 3.0.0
 
+  nostics@1.1.4: {}
+
   npm-run-path@5.3.0:
     dependencies:
       path-key: 4.0.0
@@ -17306,6 +17454,8 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  picomatch@4.0.5: {}
 
   pify@2.3.0: {}
 
@@ -18841,6 +18991,11 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.4
 
+  unplugin-utils@0.3.2:
+    dependencies:
+      pathe: 2.0.3
+      picomatch: 4.0.4
+
   unplugin-vue-components@32.1.0(@nuxt/kit@4.2.2(magicast@0.5.3))(vue@3.5.38(typescript@6.0.3)):
     dependencies:
       chokidar: 5.0.0
@@ -18893,6 +19048,28 @@ snapshots:
       '@jridgewell/remapping': 2.3.5
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
+
+  unplugin@3.3.0(esbuild@0.28.0)(rollup@4.60.3)(vite@7.3.5(@types/node@24.13.2)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      picomatch: 4.0.4
+      webpack-virtual-modules: 0.6.2
+    optionalDependencies:
+      esbuild: 0.28.0
+      rollup: 4.60.3
+      vite: 7.3.5(@types/node@24.13.2)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0)
+      webpack: 5.104.1(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
+
+  unplugin@3.3.0(esbuild@0.28.0)(rollup@4.60.3)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      picomatch: 4.0.4
+      webpack-virtual-modules: 0.6.2
+    optionalDependencies:
+      esbuild: 0.28.0
+      rollup: 4.60.3
+      vite: 7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0)
+      webpack: 5.104.1(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
   unrouting@0.1.7:
     dependencies:
@@ -19292,30 +19469,6 @@ snapshots:
       '@vue/devtools-api': 6.6.4
       vue: 3.5.38(typescript@6.0.3)
 
-  vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(vite@7.3.5(@types/node@24.13.2)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3)):
-    dependencies:
-      '@babel/generator': 8.0.0-rc.5
-      '@vue-macros/common': 3.1.2(vue@3.5.38(typescript@6.0.3))
-      '@vue/devtools-api': 8.1.2
-      ast-walker-scope: 0.9.0
-      chokidar: 5.0.0
-      json5: 2.2.3
-      local-pkg: 1.2.1
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      muggle-string: 0.4.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      scule: 1.3.0
-      tinyglobby: 0.2.17
-      unplugin: 3.0.0
-      unplugin-utils: 0.3.1
-      vue: 3.5.38(typescript@6.0.3)
-      yaml: 2.9.0
-    optionalDependencies:
-      '@vue/compiler-sfc': 3.5.38
-      vite: 7.3.5(@types/node@24.13.2)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0)
-
   vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3)):
     dependencies:
       '@babel/generator': 8.0.0-rc.5
@@ -19339,6 +19492,74 @@ snapshots:
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.38
       vite: 7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0)
+
+  vue-router@5.2.0(@vue/compiler-sfc@3.5.38)(esbuild@0.28.0)(rollup@4.60.3)(vite@7.3.5(@types/node@24.13.2)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))(webpack@5.104.1(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
+    dependencies:
+      '@babel/generator': 8.0.0
+      '@vue-macros/common': 3.1.3(vue@3.5.38(typescript@6.0.3))
+      '@vue/devtools-api': 8.1.5
+      ast-walker-scope: 0.9.0
+      chokidar: 5.0.0
+      json5: 2.2.3
+      local-pkg: 1.2.1
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      muggle-string: 0.4.1
+      nostics: 1.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      scule: 1.3.0
+      tinyglobby: 0.2.17
+      unplugin: 3.3.0(esbuild@0.28.0)(rollup@4.60.3)(vite@7.3.5(@types/node@24.13.2)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      unplugin-utils: 0.3.2
+      vue: 3.5.38(typescript@6.0.3)
+      yaml: 2.9.0
+    optionalDependencies:
+      '@vue/compiler-sfc': 3.5.38
+      vite: 7.3.5(@types/node@24.13.2)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rolldown
+      - rollup
+      - unloader
+      - webpack
+
+  vue-router@5.2.0(@vue/compiler-sfc@3.5.38)(esbuild@0.28.0)(rollup@4.60.3)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))(webpack@5.104.1(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
+    dependencies:
+      '@babel/generator': 8.0.0
+      '@vue-macros/common': 3.1.3(vue@3.5.38(typescript@6.0.3))
+      '@vue/devtools-api': 8.1.5
+      ast-walker-scope: 0.9.0
+      chokidar: 5.0.0
+      json5: 2.2.3
+      local-pkg: 1.2.1
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      muggle-string: 0.4.1
+      nostics: 1.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      scule: 1.3.0
+      tinyglobby: 0.2.17
+      unplugin: 3.3.0(esbuild@0.28.0)(rollup@4.60.3)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      unplugin-utils: 0.3.2
+      vue: 3.5.38(typescript@6.0.3)
+      yaml: 2.9.0
+    optionalDependencies:
+      '@vue/compiler-sfc': 3.5.38
+      vite: 7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rolldown
+      - rollup
+      - unloader
+      - webpack
 
   vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.38)(esbuild@0.28.0)(vue@3.5.38(typescript@6.0.3)):
     dependencies:

--- a/test/base-url.test.ts
+++ b/test/base-url.test.ts
@@ -2,7 +2,10 @@ import { fileURLToPath } from 'node:url'
 import { describe, it, expect } from 'vitest'
 import { setup, $fetch } from '@nuxt/test-utils'
 
+import { mockAdobeFetch } from './fixtures/adobe'
 import { extractPreloadLinks } from './utils'
+
+mockAdobeFetch()
 
 await setup({
   rootDir: fileURLToPath(new URL('../playgrounds/basic', import.meta.url)),

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -16,7 +16,7 @@ describe('providers', async () => {
     const html = await $fetch<string>('/providers/local')
     expect(extractFontFaces('Custom Font', html)).toMatchInlineSnapshot(`
       [
-        "@font-face{font-family:Custom Font;src:local("Custom Font Regular"),local("Custom Font"),url(/custom-font.woff2) format(woff2);font-display:swap;font-weight:400;font-style:normal}",
+        "@font-face{font-display:swap;font-family:Custom Font;font-style:normal;font-weight:400;src:local(Custom Font Regular),local(Custom Font),url(/custom-font.woff2) format(woff2)}",
       ]
     `)
   })
@@ -25,14 +25,14 @@ describe('providers', async () => {
     const html = await $fetch<string>('/providers/adobe')
     expect(extractFontFaces('Aleo', html)).toMatchInlineSnapshot(`
       [
-        "@font-face{font-family:Aleo;src:local("Aleo Regular Italic"),local("Aleo Italic"),url(/_fonts/file.woff2) format(woff2),url(/_fonts/file.woff) format(woff),url(/_fonts/file.otf) format(opentype);font-display:auto;font-weight:400;font-style:italic}",
-        "@font-face{font-family:Aleo;src:local("Aleo Regular"),local("Aleo"),url(/_fonts/file.woff2) format(woff2),url(/_fonts/file.woff) format(woff),url(/_fonts/file.otf) format(opentype);font-display:auto;font-weight:400;font-style:normal}",
+        "@font-face{font-display:auto;font-family:Aleo;font-style:italic;font-weight:400;src:local(Aleo Regular Italic),local(Aleo Italic),url(/_fonts/file.woff2) format(woff2),url(/_fonts/file.woff) format(woff),url(/_fonts/file.otf) format(opentype)}",
+        "@font-face{font-display:auto;font-family:Aleo;font-style:normal;font-weight:400;src:local(Aleo Regular),local(Aleo),url(/_fonts/file.woff2) format(woff2),url(/_fonts/file.woff) format(woff),url(/_fonts/file.otf) format(opentype)}",
       ]
     `)
     expect(extractFontFaces('Barlow Semi Condensed', html)).toMatchInlineSnapshot(`
       [
-        "@font-face{font-family:Barlow Semi Condensed;src:local("Barlow Semi Condensed Regular"),local("Barlow Semi Condensed"),url(/_fonts/file.woff2) format(woff2),url(/_fonts/file.woff) format(woff),url(/_fonts/file.otf) format(opentype);font-display:auto;font-weight:400;font-style:normal}",
-        "@font-face{font-family:Barlow Semi Condensed;src:local("Barlow Semi Condensed Regular Italic"),local("Barlow Semi Condensed Italic"),url(/_fonts/file.woff2) format(woff2),url(/_fonts/file.woff) format(woff),url(/_fonts/file.otf) format(opentype);font-display:auto;font-weight:400;font-style:italic}",
+        "@font-face{font-display:auto;font-family:Barlow Semi Condensed;font-style:normal;font-weight:400;src:local(Barlow Semi Condensed Regular),local(Barlow Semi Condensed),url(/_fonts/file.woff2) format(woff2),url(/_fonts/file.woff) format(woff),url(/_fonts/file.otf) format(opentype)}",
+        "@font-face{font-display:auto;font-family:Barlow Semi Condensed;font-style:italic;font-weight:400;src:local(Barlow Semi Condensed Regular Italic),local(Barlow Semi Condensed Italic),url(/_fonts/file.woff2) format(woff2),url(/_fonts/file.woff) format(woff),url(/_fonts/file.otf) format(opentype)}",
       ]
     `)
   })
@@ -41,7 +41,7 @@ describe('providers', async () => {
     const html = await $fetch<string>('/providers/bunny')
     expect(extractFontFaces('Abel', html)).toMatchInlineSnapshot(`
       [
-        "@font-face{font-family:Abel;src:local("Abel Regular"),local("Abel"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;font-weight:400;font-style:normal}",
+        "@font-face{font-display:swap;font-family:Abel;font-style:normal;font-weight:400;src:local(Abel Regular),local(Abel),url(/_fonts/file.woff2) format(woff2);unicode-range:U+0-FF,U+131,U+152-153,U+2BB-2BC,U+2C6,U+2DA,U+2DC,U+304,U+308,U+329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}",
       ]
     `)
   })
@@ -50,8 +50,8 @@ describe('providers', async () => {
     const html = await $fetch<string>('/providers/fontshare')
     expect(extractFontFaces('Satoshi', html)).toMatchInlineSnapshot(`
       [
-        "@font-face{font-family:Satoshi;src:local("Satoshi Regular"),local("Satoshi"),url(/_fonts/file.woff2) format(woff2);font-display:swap;font-weight:400;font-style:normal}",
-        "@font-face{font-family:Satoshi;src:local("Satoshi Regular Italic"),local("Satoshi Italic"),url(/_fonts/file.woff2) format(woff2);font-display:swap;font-weight:400;font-style:italic}",
+        "@font-face{font-display:swap;font-family:Satoshi;font-style:normal;font-weight:400;src:local(Satoshi Regular),local(Satoshi),url(/_fonts/file.woff2) format(woff2)}",
+        "@font-face{font-display:swap;font-family:Satoshi;font-style:italic;font-weight:400;src:local(Satoshi Regular Italic),local(Satoshi Italic),url(/_fonts/file.woff2) format(woff2)}",
       ]
     `)
   })
@@ -60,28 +60,28 @@ describe('providers', async () => {
     const html = await $fetch<string>('/providers/fontsource')
     expect(extractFontFaces('Roboto Flex', html)).toMatchInlineSnapshot(`
       [
-        "@font-face{font-family:Roboto Flex;src:local("Roboto Flex Regular"),local("Roboto Flex"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0460-052F,U+1C80-1C8A,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F;font-weight:400;font-style:normal}",
-        "@font-face{font-family:Roboto Flex;src:local("Roboto Flex Regular"),local("Roboto Flex"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0301,U+0400-045F,U+0490-0491,U+04B0-04B1,U+2116;font-weight:400;font-style:normal}",
-        "@font-face{font-family:Roboto Flex;src:local("Roboto Flex Regular"),local("Roboto Flex"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0370-0377,U+037A-037F,U+0384-038A,U+038C,U+038E-03A1,U+03A3-03FF;font-weight:400;font-style:normal}",
-        "@font-face{font-family:Roboto Flex;src:local("Roboto Flex Regular"),local("Roboto Flex"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0102-0103,U+0110-0111,U+0128-0129,U+0168-0169,U+01A0-01A1,U+01AF-01B0,U+0300-0301,U+0303-0304,U+0308-0309,U+0323,U+0329,U+1EA0-1EF9,U+20AB;font-weight:400;font-style:normal}",
-        "@font-face{font-family:Roboto Flex;src:local("Roboto Flex Regular"),local("Roboto Flex"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;font-weight:400;font-style:normal}",
-        "@font-face{font-family:Roboto Flex;src:local("Roboto Flex Regular"),local("Roboto Flex"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;font-weight:400;font-style:normal}",
+        "@font-face{font-display:swap;font-family:Roboto Flex;font-style:normal;font-weight:400;src:local(Roboto Flex Regular),local(Roboto Flex),url(/_fonts/file.woff2) format(woff2);unicode-range:U+460-52F,U+1C80-1C8A,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F}",
+        "@font-face{font-display:swap;font-family:Roboto Flex;font-style:normal;font-weight:400;src:local(Roboto Flex Regular),local(Roboto Flex),url(/_fonts/file.woff2) format(woff2);unicode-range:U+301,U+400-45F,U+490-491,U+4B0-4B1,U+2116}",
+        "@font-face{font-display:swap;font-family:Roboto Flex;font-style:normal;font-weight:400;src:local(Roboto Flex Regular),local(Roboto Flex),url(/_fonts/file.woff2) format(woff2);unicode-range:U+370-377,U+37A-37F,U+384-38A,U+38C,U+38E-3A1,U+3A3-3FF}",
+        "@font-face{font-display:swap;font-family:Roboto Flex;font-style:normal;font-weight:400;src:local(Roboto Flex Regular),local(Roboto Flex),url(/_fonts/file.woff2) format(woff2);unicode-range:U+102-103,U+110-111,U+128-129,U+168-169,U+1A0-1A1,U+1AF-1B0,U+300-301,U+303-304,U+308-309,U+323,U+329,U+1EA0-1EF9,U+20AB}",
+        "@font-face{font-display:swap;font-family:Roboto Flex;font-style:normal;font-weight:400;src:local(Roboto Flex Regular),local(Roboto Flex),url(/_fonts/file.woff2) format(woff2);unicode-range:U+100-2BA,U+2BD-2C5,U+2C7-2CC,U+2CE-2D7,U+2DD-2FF,U+304,U+308,U+329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF}",
+        "@font-face{font-display:swap;font-family:Roboto Flex;font-style:normal;font-weight:400;src:local(Roboto Flex Regular),local(Roboto Flex),url(/_fonts/file.woff2) format(woff2);unicode-range:U+0-FF,U+131,U+152-153,U+2BB-2BC,U+2C6,U+2DA,U+2DC,U+304,U+308,U+329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}",
       ]
     `)
     expect(extractFontFaces('Roboto Mono', html)).toMatchInlineSnapshot(`
       [
-        "@font-face{font-family:Roboto Mono;src:local("Roboto Mono Regular"),local("Roboto Mono"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0460-052F,U+1C80-1C8A,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F;font-weight:400;font-style:normal}",
-        "@font-face{font-family:Roboto Mono;src:local("Roboto Mono Regular Italic"),local("Roboto Mono Italic"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0460-052F,U+1C80-1C8A,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F;font-weight:400;font-style:italic}",
-        "@font-face{font-family:Roboto Mono;src:local("Roboto Mono Regular"),local("Roboto Mono"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0301,U+0400-045F,U+0490-0491,U+04B0-04B1,U+2116;font-weight:400;font-style:normal}",
-        "@font-face{font-family:Roboto Mono;src:local("Roboto Mono Regular Italic"),local("Roboto Mono Italic"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0301,U+0400-045F,U+0490-0491,U+04B0-04B1,U+2116;font-weight:400;font-style:italic}",
-        "@font-face{font-family:Roboto Mono;src:local("Roboto Mono Regular"),local("Roboto Mono"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0370-0377,U+037A-037F,U+0384-038A,U+038C,U+038E-03A1,U+03A3-03FF;font-weight:400;font-style:normal}",
-        "@font-face{font-family:Roboto Mono;src:local("Roboto Mono Regular Italic"),local("Roboto Mono Italic"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0370-0377,U+037A-037F,U+0384-038A,U+038C,U+038E-03A1,U+03A3-03FF;font-weight:400;font-style:italic}",
-        "@font-face{font-family:Roboto Mono;src:local("Roboto Mono Regular"),local("Roboto Mono"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0102-0103,U+0110-0111,U+0128-0129,U+0168-0169,U+01A0-01A1,U+01AF-01B0,U+0300-0301,U+0303-0304,U+0308-0309,U+0323,U+0329,U+1EA0-1EF9,U+20AB;font-weight:400;font-style:normal}",
-        "@font-face{font-family:Roboto Mono;src:local("Roboto Mono Regular Italic"),local("Roboto Mono Italic"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0102-0103,U+0110-0111,U+0128-0129,U+0168-0169,U+01A0-01A1,U+01AF-01B0,U+0300-0301,U+0303-0304,U+0308-0309,U+0323,U+0329,U+1EA0-1EF9,U+20AB;font-weight:400;font-style:italic}",
-        "@font-face{font-family:Roboto Mono;src:local("Roboto Mono Regular"),local("Roboto Mono"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;font-weight:400;font-style:normal}",
-        "@font-face{font-family:Roboto Mono;src:local("Roboto Mono Regular Italic"),local("Roboto Mono Italic"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;font-weight:400;font-style:italic}",
-        "@font-face{font-family:Roboto Mono;src:local("Roboto Mono Regular"),local("Roboto Mono"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;font-weight:400;font-style:normal}",
-        "@font-face{font-family:Roboto Mono;src:local("Roboto Mono Regular Italic"),local("Roboto Mono Italic"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;font-weight:400;font-style:italic}",
+        "@font-face{font-display:swap;font-family:Roboto Mono;font-style:normal;font-weight:400;src:local(Roboto Mono Regular),local(Roboto Mono),url(/_fonts/file.woff2) format(woff2);unicode-range:U+460-52F,U+1C80-1C8A,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F}",
+        "@font-face{font-display:swap;font-family:Roboto Mono;font-style:italic;font-weight:400;src:local(Roboto Mono Regular Italic),local(Roboto Mono Italic),url(/_fonts/file.woff2) format(woff2);unicode-range:U+460-52F,U+1C80-1C8A,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F}",
+        "@font-face{font-display:swap;font-family:Roboto Mono;font-style:normal;font-weight:400;src:local(Roboto Mono Regular),local(Roboto Mono),url(/_fonts/file.woff2) format(woff2);unicode-range:U+301,U+400-45F,U+490-491,U+4B0-4B1,U+2116}",
+        "@font-face{font-display:swap;font-family:Roboto Mono;font-style:italic;font-weight:400;src:local(Roboto Mono Regular Italic),local(Roboto Mono Italic),url(/_fonts/file.woff2) format(woff2);unicode-range:U+301,U+400-45F,U+490-491,U+4B0-4B1,U+2116}",
+        "@font-face{font-display:swap;font-family:Roboto Mono;font-style:normal;font-weight:400;src:local(Roboto Mono Regular),local(Roboto Mono),url(/_fonts/file.woff2) format(woff2);unicode-range:U+370-377,U+37A-37F,U+384-38A,U+38C,U+38E-3A1,U+3A3-3FF}",
+        "@font-face{font-display:swap;font-family:Roboto Mono;font-style:italic;font-weight:400;src:local(Roboto Mono Regular Italic),local(Roboto Mono Italic),url(/_fonts/file.woff2) format(woff2);unicode-range:U+370-377,U+37A-37F,U+384-38A,U+38C,U+38E-3A1,U+3A3-3FF}",
+        "@font-face{font-display:swap;font-family:Roboto Mono;font-style:normal;font-weight:400;src:local(Roboto Mono Regular),local(Roboto Mono),url(/_fonts/file.woff2) format(woff2);unicode-range:U+102-103,U+110-111,U+128-129,U+168-169,U+1A0-1A1,U+1AF-1B0,U+300-301,U+303-304,U+308-309,U+323,U+329,U+1EA0-1EF9,U+20AB}",
+        "@font-face{font-display:swap;font-family:Roboto Mono;font-style:italic;font-weight:400;src:local(Roboto Mono Regular Italic),local(Roboto Mono Italic),url(/_fonts/file.woff2) format(woff2);unicode-range:U+102-103,U+110-111,U+128-129,U+168-169,U+1A0-1A1,U+1AF-1B0,U+300-301,U+303-304,U+308-309,U+323,U+329,U+1EA0-1EF9,U+20AB}",
+        "@font-face{font-display:swap;font-family:Roboto Mono;font-style:normal;font-weight:400;src:local(Roboto Mono Regular),local(Roboto Mono),url(/_fonts/file.woff2) format(woff2);unicode-range:U+100-2BA,U+2BD-2C5,U+2C7-2CC,U+2CE-2D7,U+2DD-2FF,U+304,U+308,U+329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF}",
+        "@font-face{font-display:swap;font-family:Roboto Mono;font-style:italic;font-weight:400;src:local(Roboto Mono Regular Italic),local(Roboto Mono Italic),url(/_fonts/file.woff2) format(woff2);unicode-range:U+100-2BA,U+2BD-2C5,U+2C7-2CC,U+2CE-2D7,U+2DD-2FF,U+304,U+308,U+329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF}",
+        "@font-face{font-display:swap;font-family:Roboto Mono;font-style:normal;font-weight:400;src:local(Roboto Mono Regular),local(Roboto Mono),url(/_fonts/file.woff2) format(woff2);unicode-range:U+0-FF,U+131,U+152-153,U+2BB-2BC,U+2C6,U+2DA,U+2DC,U+304,U+308,U+329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}",
+        "@font-face{font-display:swap;font-family:Roboto Mono;font-style:italic;font-weight:400;src:local(Roboto Mono Regular Italic),local(Roboto Mono Italic),url(/_fonts/file.woff2) format(woff2);unicode-range:U+0-FF,U+131,U+152-153,U+2BB-2BC,U+2C6,U+2DA,U+2DC,U+304,U+308,U+329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}",
       ]
     `)
   })
@@ -94,14 +94,14 @@ describe('providers', async () => {
     expect(poppins.length).toMatchInlineSnapshot(`4`)
     // No `@font-face` is generated for second/fallback fonts
     expect(raleway.length).toMatchInlineSnapshot(`0`)
-    expect(poppins[0]).toMatchInlineSnapshot(`"@font-face{font-family:Poppins;src:local("Poppins Regular Italic"),local("Poppins Italic"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;font-weight:400;font-style:italic}"`)
+    expect(poppins[0]).toMatchInlineSnapshot(`"@font-face{font-display:swap;font-family:Poppins;font-style:italic;font-weight:400;src:local(Poppins Regular Italic),local(Poppins Italic),url(/_fonts/file.woff2) format(woff2);unicode-range:U+100-2BA,U+2BD-2C5,U+2C7-2CC,U+2CE-2D7,U+2DD-2FF,U+304,U+308,U+329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF}"`)
     expect(press).toMatchInlineSnapshot(`
       [
-        "@font-face{font-family:"Press Start 2P";src:local("Press Start 2P Regular"),local("Press Start 2P"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0460-052F,U+1C80-1C8A,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F;font-weight:400;font-style:normal}",
-        "@font-face{font-family:"Press Start 2P";src:local("Press Start 2P Regular"),local("Press Start 2P"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0301,U+0400-045F,U+0490-0491,U+04B0-04B1,U+2116;font-weight:400;font-style:normal}",
-        "@font-face{font-family:"Press Start 2P";src:local("Press Start 2P Regular"),local("Press Start 2P"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0370-0377,U+037A-037F,U+0384-038A,U+038C,U+038E-03A1,U+03A3-03FF;font-weight:400;font-style:normal}",
-        "@font-face{font-family:"Press Start 2P";src:local("Press Start 2P Regular"),local("Press Start 2P"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;font-weight:400;font-style:normal}",
-        "@font-face{font-family:"Press Start 2P";src:local("Press Start 2P Regular"),local("Press Start 2P"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;font-weight:400;font-style:normal}",
+        "@font-face{font-display:swap;font-family:Press Start 2P;font-style:normal;font-weight:400;src:local(Press Start 2P Regular),local(Press Start 2P),url(/_fonts/file.woff2) format(woff2);unicode-range:U+460-52F,U+1C80-1C8A,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F}",
+        "@font-face{font-display:swap;font-family:Press Start 2P;font-style:normal;font-weight:400;src:local(Press Start 2P Regular),local(Press Start 2P),url(/_fonts/file.woff2) format(woff2);unicode-range:U+301,U+400-45F,U+490-491,U+4B0-4B1,U+2116}",
+        "@font-face{font-display:swap;font-family:Press Start 2P;font-style:normal;font-weight:400;src:local(Press Start 2P Regular),local(Press Start 2P),url(/_fonts/file.woff2) format(woff2);unicode-range:U+370-377,U+37A-37F,U+384-38A,U+38C,U+38E-3A1,U+3A3-3FF}",
+        "@font-face{font-display:swap;font-family:Press Start 2P;font-style:normal;font-weight:400;src:local(Press Start 2P Regular),local(Press Start 2P),url(/_fonts/file.woff2) format(woff2);unicode-range:U+100-2BA,U+2BD-2C5,U+2C7-2CC,U+2CE-2D7,U+2DD-2FF,U+304,U+308,U+329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF}",
+        "@font-face{font-display:swap;font-family:Press Start 2P;font-style:normal;font-weight:400;src:local(Press Start 2P Regular),local(Press Start 2P),url(/_fonts/file.woff2) format(woff2);unicode-range:U+0-FF,U+131,U+152-153,U+2BB-2BC,U+2C6,U+2DA,U+2DC,U+304,U+308,U+329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}",
       ]
     `)
   })
@@ -110,9 +110,9 @@ describe('providers', async () => {
     const html = await $fetch<string>('/providers/npm')
     expect(extractFontFaces('Cal Sans', html)).toMatchInlineSnapshot(`
       [
-        "@font-face{font-family:Cal Sans;src:local("Cal Sans Regular"),local("Cal Sans"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0102-0103,U+0110-0111,U+0128-0129,U+0168-0169,U+01A0-01A1,U+01AF-01B0,U+0300-0301,U+0303-0304,U+0308-0309,U+0323,U+0329,U+1EA0-1EF9,U+20AB;font-weight:400;font-style:normal}",
-        "@font-face{font-family:Cal Sans;src:local("Cal Sans Regular"),local("Cal Sans"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;font-weight:400;font-style:normal}",
-        "@font-face{font-family:Cal Sans;src:local("Cal Sans Regular"),local("Cal Sans"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;font-weight:400;font-style:normal}",
+        "@font-face{font-display:swap;font-family:Cal Sans;font-style:normal;font-weight:400;src:local(Cal Sans Regular),local(Cal Sans),url(/_fonts/file.woff2) format(woff2);unicode-range:U+102-103,U+110-111,U+128-129,U+168-169,U+1A0-1A1,U+1AF-1B0,U+300-301,U+303-304,U+308-309,U+323,U+329,U+1EA0-1EF9,U+20AB}",
+        "@font-face{font-display:swap;font-family:Cal Sans;font-style:normal;font-weight:400;src:local(Cal Sans Regular),local(Cal Sans),url(/_fonts/file.woff2) format(woff2);unicode-range:U+100-2BA,U+2BD-2C5,U+2C7-2CC,U+2CE-2D7,U+2DD-2FF,U+304,U+308,U+329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF}",
+        "@font-face{font-display:swap;font-family:Cal Sans;font-style:normal;font-weight:400;src:local(Cal Sans Regular),local(Cal Sans),url(/_fonts/file.woff2) format(woff2);unicode-range:U+0-FF,U+131,U+152-153,U+2BB-2BC,U+2C6,U+2DA,U+2DC,U+304,U+308,U+329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}",
       ]
     `)
   })
@@ -126,7 +126,7 @@ describe('providers', async () => {
     const html = await $fetch<string>('/providers/custom')
     expect(extractFontFaces('SomeFontFromCustomProvider', html)).toMatchInlineSnapshot(`
       [
-        "@font-face{font-family:SomeFontFromCustomProvider;src:url(/some-font.woff2) format(woff2);font-display:swap}",
+        "@font-face{font-display:swap;font-family:SomeFontFromCustomProvider;src:url(/some-font.woff2) format(woff2)}",
       ]
     `)
   })
@@ -135,7 +135,7 @@ describe('providers', async () => {
     const html = await $fetch<string>('/providers/custom')
     expect(extractFontFaces('SomeFontFromLegacyCustomProvider', html)).toMatchInlineSnapshot(`
       [
-        "@font-face{font-family:SomeFontFromLegacyCustomProvider;src:url(/some-font.woff2) format(woff2);font-display:swap}",
+        "@font-face{font-display:swap;font-family:SomeFontFromLegacyCustomProvider;src:url(/some-font.woff2) format(woff2)}",
       ]
     `)
   })
@@ -146,7 +146,7 @@ describe('features', () => {
     const html = await $fetch<string>('/overrides')
     expect(extractFontFaces('MyCustom', html)).toMatchInlineSnapshot(`
       [
-        "@font-face{font-family:MyCustom;src:url(/custom-font.woff2) format(woff2);font-display:swap}",
+        "@font-face{font-display:swap;font-family:MyCustom;src:url(/custom-font.woff2) format(woff2)}",
       ]
     `)
   })
@@ -164,12 +164,12 @@ describe('features', () => {
     const html = await $fetch<string>('/fallbacks')
     expect(extractFontFaces('Lato Fallback: Arial', html)).toMatchInlineSnapshot(`
       [
-        "@font-face{font-family:"Lato Fallback: Arial";src:local("Arial");size-adjust:97.6894%;ascent-override:101.0345%;descent-override:21.8038%;line-gap-override:0%}",
+        "@font-face{ascent-override:101.035%;descent-override:21.8038%;font-family:Lato Fallback: Arial;line-gap-override:0%;size-adjust:97.6894%;src:local(Arial)}",
       ]
     `)
     expect(extractFontFaces('Nunito Fallback: Arial', html)).toMatchInlineSnapshot(`
       [
-        "@font-face{font-family:"Nunito Fallback: Arial";src:local("Arial");size-adjust:101.3906%;ascent-override:99.7134%;descent-override:34.8159%;line-gap-override:0%}",
+        "@font-face{ascent-override:99.7134%;descent-override:34.8159%;font-family:Nunito Fallback: Arial;line-gap-override:0%;size-adjust:101.391%;src:local(Arial)}",
       ]
     `)
   })
@@ -178,25 +178,19 @@ describe('features', () => {
     const html = await $fetch<string>('/fallbacks')
     expect(extractFontFaces('Oswald Fallback: Times New Roman', html)).toMatchInlineSnapshot(`
       [
-        "@font-face{font-family:"Oswald Fallback: Times New Roman";src:local("Times New Roman");size-adjust:89.3538%;ascent-override:133.5141%;descent-override:32.3433%;line-gap-override:0%}",
+        "@font-face{ascent-override:133.514%;descent-override:32.3433%;font-family:Oswald Fallback: Times New Roman;line-gap-override:0%;size-adjust:89.3538%;src:local(Times New Roman)}",
       ]
     `)
     expect(extractFontFaces('Fredoka Fallback: Tahoma', html)).toMatchInlineSnapshot(`
       [
-        "@font-face{font-family:"Fredoka Fallback: Tahoma";src:local("Tahoma");size-adjust:101.395%;ascent-override:96.06%;descent-override:23.2753%;line-gap-override:0%}",
+        "@font-face{ascent-override:96.06%;descent-override:23.2753%;font-family:Fredoka Fallback: Tahoma;line-gap-override:0%;size-adjust:101.395%;src:local(Tahoma)}",
       ]
     `)
   })
 
   it('only processes css variables prefixed with --font by default', async () => {
     const html = await $fetch<string>('/css-variable')
-    expect(extractFontFaces('Sigmar', html)).toMatchInlineSnapshot(`
-      [
-        "@font-face{font-family:Sigmar One;src:local("Sigmar One Regular"),local("Sigmar One"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0102-0103,U+0110-0111,U+0128-0129,U+0168-0169,U+01A0-01A1,U+01AF-01B0,U+0300-0301,U+0303-0304,U+0308-0309,U+0323,U+0329,U+1EA0-1EF9,U+20AB;font-weight:400;font-style:normal}",
-        "@font-face{font-family:Sigmar One;src:local("Sigmar One Regular"),local("Sigmar One"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;font-weight:400;font-style:normal}",
-        "@font-face{font-family:Sigmar One;src:local("Sigmar One Regular"),local("Sigmar One"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;font-weight:400;font-style:normal}",
-      ]
-    `)
+    expect(extractFontFaces('Sigmar', html)).toMatchInlineSnapshot(`[]`)
   })
 
   it('adds preload links to the HTML with locally scoped rules', async () => {

--- a/test/css-frameworks/scss.test.ts
+++ b/test/css-frameworks/scss.test.ts
@@ -13,8 +13,8 @@ describe('scss features', () => {
     const html = await $fetch<string>('/')
     expect(extractFontFaces('Anta', html)).toMatchInlineSnapshot(`
       [
-        "@font-face{font-family:Anta;src:local("Anta Regular"),local("Anta"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;font-weight:400;font-style:normal}",
-        "@font-face{font-family:Anta;src:local("Anta Regular"),local("Anta"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;font-weight:400;font-style:normal}",
+        "@font-face{font-display:swap;font-family:Anta;font-style:normal;font-weight:400;src:local(Anta Regular),local(Anta),url(/_fonts/file.woff2) format(woff2);unicode-range:U+100-2BA,U+2BD-2C5,U+2C7-2CC,U+2CE-2D7,U+2DD-2FF,U+304,U+308,U+329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF}",
+        "@font-face{font-display:swap;font-family:Anta;font-style:normal;font-weight:400;src:local(Anta Regular),local(Anta),url(/_fonts/file.woff2) format(woff2);unicode-range:U+0-FF,U+131,U+152-153,U+2BB-2BC,U+2C6,U+2DA,U+2DC,U+304,U+308,U+329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}",
       ]
     `)
   })

--- a/test/css-frameworks/tailwind@3.test.ts
+++ b/test/css-frameworks/tailwind@3.test.ts
@@ -13,9 +13,9 @@ describe('tailwindcss@3 features', () => {
     const html = await $fetch<string>('/')
     expect(extractFontFaces('Anton', html)).toMatchInlineSnapshot(`
       [
-        "@font-face{font-family:Anton;src:local("Anton Regular"),local("Anton"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0102-0103,U+0110-0111,U+0128-0129,U+0168-0169,U+01A0-01A1,U+01AF-01B0,U+0300-0301,U+0303-0304,U+0308-0309,U+0323,U+0329,U+1EA0-1EF9,U+20AB;font-weight:400;font-style:normal}",
-        "@font-face{font-family:Anton;src:local("Anton Regular"),local("Anton"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;font-weight:400;font-style:normal}",
-        "@font-face{font-family:Anton;src:local("Anton Regular"),local("Anton"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;font-weight:400;font-style:normal}",
+        "@font-face{font-display:swap;font-family:Anton;font-style:normal;font-weight:400;src:local(Anton Regular),local(Anton),url(/_fonts/file.woff2) format(woff2);unicode-range:U+102-103,U+110-111,U+128-129,U+168-169,U+1A0-1A1,U+1AF-1B0,U+300-301,U+303-304,U+308-309,U+323,U+329,U+1EA0-1EF9,U+20AB}",
+        "@font-face{font-display:swap;font-family:Anton;font-style:normal;font-weight:400;src:local(Anton Regular),local(Anton),url(/_fonts/file.woff2) format(woff2);unicode-range:U+100-2BA,U+2BD-2C5,U+2C7-2CC,U+2CE-2D7,U+2DD-2FF,U+304,U+308,U+329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF}",
+        "@font-face{font-display:swap;font-family:Anton;font-style:normal;font-weight:400;src:local(Anton Regular),local(Anton),url(/_fonts/file.woff2) format(woff2);unicode-range:U+0-FF,U+131,U+152-153,U+2BB-2BC,U+2C6,U+2DA,U+2DC,U+304,U+308,U+329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}",
       ]
     `)
   })

--- a/test/css-frameworks/tailwind@4.test.ts
+++ b/test/css-frameworks/tailwind@4.test.ts
@@ -13,9 +13,9 @@ describe('tailwindcss@4 features', () => {
     const html = await $fetch<string>('/')
     expect(extractFontFaces('Anton', html)).toMatchInlineSnapshot(`
       [
-        "@font-face{font-family:Anton;src:local("Anton Regular"),local("Anton"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0102-0103,U+0110-0111,U+0128-0129,U+0168-0169,U+01A0-01A1,U+01AF-01B0,U+0300-0301,U+0303-0304,U+0308-0309,U+0323,U+0329,U+1EA0-1EF9,U+20AB;font-weight:400;font-style:normal}",
-        "@font-face{font-family:Anton;src:local("Anton Regular"),local("Anton"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;font-weight:400;font-style:normal}",
-        "@font-face{font-family:Anton;src:local("Anton Regular"),local("Anton"),url(/_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;font-weight:400;font-style:normal}",
+        "@font-face{font-display:swap;font-family:Anton;font-style:normal;font-weight:400;src:local(Anton Regular),local(Anton),url(/_fonts/file.woff2) format(woff2);unicode-range:U+102-103,U+110-111,U+128-129,U+168-169,U+1A0-1A1,U+1AF-1B0,U+300-301,U+303-304,U+308-309,U+323,U+329,U+1EA0-1EF9,U+20AB}",
+        "@font-face{font-display:swap;font-family:Anton;font-style:normal;font-weight:400;src:local(Anton Regular),local(Anton),url(/_fonts/file.woff2) format(woff2);unicode-range:U+100-2BA,U+2BD-2C5,U+2C7-2CC,U+2CE-2D7,U+2DD-2FF,U+304,U+308,U+329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF}",
+        "@font-face{font-display:swap;font-family:Anton;font-style:normal;font-weight:400;src:local(Anton Regular),local(Anton),url(/_fonts/file.woff2) format(woff2);unicode-range:U+0-FF,U+131,U+152-153,U+2BB-2BC,U+2C6,U+2DA,U+2DC,U+304,U+308,U+329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}",
       ]
     `)
   })

--- a/test/css-frameworks/unocss.test.ts
+++ b/test/css-frameworks/unocss.test.ts
@@ -15,6 +15,6 @@ describe('unocss features', () => {
     const css = await $fetch<string>(cssFile)
     const barlow = extractFontFaces('Barlow', css)
     expect(barlow.length).toMatchInlineSnapshot(`6`)
-    expect(barlow[0]).toMatchInlineSnapshot(`"@font-face{font-family:Barlow;src:local("Barlow Regular Italic"),local("Barlow Italic"),url(../_fonts/file.woff2) format(woff2);font-display:swap;unicode-range:U+0102-0103,U+0110-0111,U+0128-0129,U+0168-0169,U+01A0-01A1,U+01AF-01B0,U+0300-0301,U+0303-0304,U+0308-0309,U+0323,U+0329,U+1EA0-1EF9,U+20AB;font-weight:400;font-style:italic}"`)
+    expect(barlow[0]).toMatchInlineSnapshot(`"@font-face{font-display:swap;font-family:Barlow;font-style:italic;font-weight:400;src:local(Barlow Regular Italic),local(Barlow Italic),url(../_fonts/file.woff2) format(woff2);unicode-range:U+102-103,U+110-111,U+128-129,U+168-169,U+1A0-1A1,U+1AF-1B0,U+300-301,U+303-304,U+308-309,U+323,U+329,U+1EA0-1EF9,U+20AB}"`)
   })
 })

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -4,11 +4,49 @@ export function extractFontFaces(fontFamily: string, html: string) {
   // `font-family:Oswald Fallback\: Times New Roman`. Allow an optional escaping
   // backslash before each colon so both serialisations match.
   const familyPattern = fontFamily.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/:/g, '\\\\?:')
-  const matches = html.matchAll(new RegExp(`@font-face\\s*{[^}]*font-family:\\s*(?<quote>['"])?${familyPattern}\\k<quote>[^}]+}`, 'g'))
-  return Array.from(matches, match => match[0]
+  // Anchor the family name to the end of the `font-family` value (`;`) so that
+  // `extractFontFaces('Poppins')` does not also match unquoted fallback
+  // families like `font-family:Poppins Fallback\: Arial`.
+  const matches = html.matchAll(new RegExp(`@font-face\\s*{[^}]*font-family:\\s*(?<quote>['"])?${familyPattern}\\k<quote>;[^}]*}`, 'g'))
+  return Array.from(matches, match => normalizeFontFace(match[0]
     .replace(/(?<=['"(])(https?:\/\/[^/]+|(?:..)?\/_fonts)\/[^")]+(\.[^".)]+)(?=['")])/g, '$1/file$2')
-    .replace(/(?<=['"(])(https?:\/\/[^/]+|(?:..)?\/_fonts)\/[^".)]+(?=['")])/g, '$1/file'),
+    .replace(/(?<=['"(])(https?:\/\/[^/]+|(?:..)?\/_fonts)\/[^".)]+(?=['")])/g, '$1/file')),
   )
+}
+
+// The exact CSS serialisation of an `@font-face` rule depends on the minifier:
+// vite 7 / esbuild keeps `local("X")`, `format(woff2)`, zero-padded `unicode-range`
+// codepoints and full-precision metric overrides, while vite 8 / lightningcss emits
+// `local(X)`, `format("woff2")`, `U+??`-style wildcards and f32 6-significant-digit
+// metrics. Fold both into one canonical shape so a single snapshot holds across minifiers.
+function normalizeFontFace(css: string) {
+  return css
+    .replace(/local\((['"])((?:[^'"\\]|\\.)*)\1\)/g, (_, _q, name) => `local(${name})`)
+    .replace(/\)\s*format\((['"]?)([^)]*?)\1\)/g, ') format($2)')
+    .replace(/font-family:(['"]?)((?:[^'";\\]|\\.)*)\1;/, (_, _q, name) => `font-family:${name.replace(/\\(.)/g, '$1')};`)
+    .replace(/unicode-range:([^;}]+)/, (_, list) => `unicode-range:${(list as string).split(',').map(normalizeUnicodeRange).join(',')}`)
+    // lightningcss stores CSS numbers as f32 and prints them to 6 significant
+    // digits; mirror that so the more precise esbuild serialisation collapses onto
+    // the same value.
+    .replace(/(\d+\.\d+)%/g, (_, n) => `${Number.parseFloat(Math.fround(Number.parseFloat(n)).toPrecision(6))}%`)
+    // lightningcss reorders `@font-face` descriptors (e.g. `font-display` moves
+    // after `src`) whereas esbuild preserves source order; sort them so the block
+    // is order-independent.
+    .replace(/(@font-face\s*\{)([^}]*)\}/g, (_, head, body) => `${head}${(body as string).split(';').filter(Boolean).sort().join(';')}}`)
+}
+
+function normalizeUnicodeRange(token: string) {
+  const match = token.trim().match(/^U\+([0-9A-Fa-f?]+)(?:-([0-9A-Fa-f]+))?$/)
+  if (!match) {
+    return token.trim()
+  }
+  let [, start, end] = match
+  if (start!.includes('?')) {
+    end = start!.replace(/\?/g, 'F')
+    start = start!.replace(/\?/g, '0')
+  }
+  const strip = (hex: string) => hex.replace(/^0+(?=.)/, '').toUpperCase()
+  return end ? `U+${strip(start!)}-${strip(end)}` : `U+${strip(start!)}`
 }
 
 export function extractPreloadLinks(html?: string) {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

spotted in [an ecosystem-ci run](https://github.com/nuxt/ecosystem-ci/actions/runs/29616277122/job/88007194708), this makes font snapshots less fragile, in particular with the upcoming v4.5 (which includes vite 8)