### PR TITLE
feat: configurable font cache

### DIFF
--- a/docs/content/1.get-started/2.configuration.md
+++ b/docs/content/1.get-started/2.configuration.md
@@ -240,6 +240,24 @@ export default defineNuxtConfig({
 })
 ```
 
+## `cache`
+
+Font metadata and downloaded font files are cached between builds in `node_modules/.cache/nuxt/fonts/meta`. You can change where that happens, provide your own [unstorage](https://unstorage.unjs.io/) instance, or turn persistent caching off (in which case an in-memory cache is used).
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  modules: ['@nuxt/fonts'],
+  fonts: {
+    // a directory, resolved relative to your project root
+    cache: '.cache/fonts',
+    // or your own storage
+    // cache: createStorage({ driver: redisDriver({ base: 'fonts' }) }),
+    // or no persistent cache at all
+    // cache: false,
+  }
+})
+```
+
 ## `priority`
 
 You can customize the order in which providers are checked.

--- a/docs/content/1.get-started/5.upgrade.md
+++ b/docs/content/1.get-started/5.upgrade.md
@@ -7,6 +7,10 @@ description: Breaking changes and migration steps when upgrading to the latest v
 
 ### Breaking Changes
 
+#### Font metadata is cached per project
+
+Font metadata and downloaded font files are now cached in `node_modules/.cache/nuxt/fonts/meta` relative to your project root rather than to the directory you run Nuxt from. The first build after upgrading will re-resolve and re-download fonts, and you can now configure the location with the new [`cache`](/get-started/configuration#cache) option.
+
 #### Injected `@font-face` rules are minified with lightningcss
 
 Generated `@font-face` declarations were previously minified with esbuild unless you had opted into `css.lightningcss`. They are now always minified with lightningcss, so the exact serialisation of the CSS we inject may differ (for example `local(Font Name)` rather than `local("Font Name")`). This is cosmetic, but it will show up in snapshot tests.
@@ -28,6 +32,18 @@ export default defineNuxtConfig({
 ```
 
 See [`preload`](/get-started/configuration#preload) for the full set of values.
+
+#### Configurable cache
+
+You can now point the font cache at a directory of your choice, pass your own [unstorage](https://unstorage.unjs.io/) instance, or disable persistent caching with `cache: false`.
+
+```ts
+export default defineNuxtConfig({
+  fonts: {
+    cache: '.cache/fonts',
+  },
+})
+```
 
 #### Custom CSS variable prefixes
 

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -12,12 +12,12 @@ import { join } from 'pathe'
 
 import { normalizeFontData } from 'fontless'
 import type { NormalizeFontDataContext } from 'fontless'
-import { storage } from './cache'
+import type { Storage, StorageValue } from 'unstorage'
 import { logger } from './logger'
 import type { ModuleOptions } from './types'
 
 // TODO: replace this with nuxt/assets when it is released
-export async function setupPublicAssetStrategy(options: ModuleOptions['assets'] = {}) {
+export async function setupPublicAssetStrategy(storage: Storage<StorageValue>, options: ModuleOptions['assets'] = {}) {
   const nuxt = useNuxt()
 
   const context: NormalizeFontDataContext = {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,9 +1,24 @@
+import { resolve } from 'pathe'
 import { createStorage } from 'unstorage'
 import fsDriver from 'unstorage/drivers/fs'
+import memoryDriver from 'unstorage/drivers/memory'
+import type { Storage, StorageValue } from 'unstorage'
+import type { ModuleOptions } from './types'
 
 export const cacheBase = 'node_modules/.cache/nuxt/fonts/meta'
 
+function isStorage(cache: ModuleOptions['cache']): cache is Storage<StorageValue> {
+  return !!cache && typeof cache === 'object' && typeof (cache as Storage).getItem === 'function'
+}
+
 // TODO: refactor to use nitro storage when possible
-export const storage = createStorage({
-  driver: fsDriver({ base: cacheBase }),
-})
+export function createFontStorage(cache: ModuleOptions['cache'], rootDir: string): Storage<StorageValue> {
+  if (cache === false) {
+    return createStorage({ driver: memoryDriver() })
+  }
+  if (isStorage(cache)) {
+    return cache
+  }
+  const dir = typeof cache === 'string' ? cache : cache?.dir
+  return createStorage({ driver: fsDriver({ base: resolve(rootDir, dir || cacheBase) }) })
+}

--- a/src/module.ts
+++ b/src/module.ts
@@ -7,7 +7,7 @@ import { withoutLeadingSlash } from 'ufo'
 import defu from 'defu'
 import { createResolver, resolveProviders, defaultOptions, defaultValues, generateFontFace } from 'fontless'
 import type { Resolver } from 'fontless'
-import { storage } from './cache'
+import { createFontStorage } from './cache'
 import { FontFamilyInjectionPlugin } from './plugins/transform'
 import { setupPublicAssetStrategy } from './assets'
 import { selectFontsToPreload } from './preload'
@@ -77,7 +77,9 @@ export default defineNuxtModule<ModuleOptions>({
 
     const _providers = resolveProviders(options.providers, { root: nuxt.options.rootDir, alias: nuxt.options.alias })
 
-    const { normalizeFontData } = await setupPublicAssetStrategy(options.assets)
+    const storage = createFontStorage(options.cache, nuxt.options.rootDir)
+
+    const { normalizeFontData } = await setupPublicAssetStrategy(storage, options.assets)
     const { exposeFont } = setupDevtoolsConnection(nuxt.options.dev && !!options.devtools)
 
     let resolveFontFaceWithOverride: Resolver

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { createStorage } from 'unstorage'
+import memoryDriver from 'unstorage/drivers/memory'
+
+import type { Storage, StorageValue } from 'unstorage'
+
+import { cacheBase, createFontStorage } from '../src/cache'
+
+function cacheDir(storage: Storage<StorageValue>) {
+  return (storage.getMount('').driver.options as { base: string }).base
+}
+
+describe('cache option', () => {
+  it('should cache in the default directory', () => {
+    const storage = createFontStorage(undefined, '/root')
+    expect(cacheDir(storage)).toBe(`/root/${cacheBase}`)
+  })
+
+  it('should accept a custom directory', () => {
+    for (const cache of ['.cache/fonts', { dir: '.cache/fonts' }]) {
+      const storage = createFontStorage(cache, '/root')
+      expect(cacheDir(storage)).toBe('/root/.cache/fonts')
+    }
+  })
+
+  it('should accept an absolute directory', () => {
+    const storage = createFontStorage('/tmp/fonts', '/root')
+    expect(cacheDir(storage)).toBe('/tmp/fonts')
+  })
+
+  it('should accept a custom storage instance', () => {
+    const cache = createStorage({ driver: memoryDriver() })
+    expect(createFontStorage(cache, '/root')).toBe(cache)
+  })
+
+  it('should not persist anything when disabled', async () => {
+    const storage = createFontStorage(false, '/root')
+    await storage.setItem('key', 'value')
+    expect(await storage.getItem('key')).toBe('value')
+    expect(storage.getMount('').driver.name).toBe('memory')
+  })
+})

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -5,7 +5,7 @@ import { cacheBase } from '../src/cache'
 export async function setup() {
   await fsp.rm('./' + cacheBase, { recursive: true, force: true })
   for (const dir of ['basic', 'scss', 'tailwindcss@3', 'tailwindcss@4', 'unocss']) {
-    await fsp.rm('./playgrounds/' + dir + cacheBase, { recursive: true, force: true })
+    await fsp.rm('./playgrounds/' + dir + '/' + cacheBase, { recursive: true, force: true })
   }
   console.log('✅ Cleared font cache.')
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

similar to https://github.com/unjs/fontaine/pull/786, we now support a configurable cache directory (or turning off cache entirely)