### PR TITLE
fix: strip style queries when tracking fonts to preload

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -131,12 +131,12 @@ export default defineNuxtModule<ModuleOptions>({
       const unprocessedPreloads = new Set([...fontMap.keys()])
       function addPreloadLinks(chunk: ResourceMeta, urls: Set<string>, id?: string) {
         chunk.assets ||= []
+        if (id) {
+          unprocessedPreloads.delete(id)
+        }
         for (const url of urls) {
           if (!chunk.assets.includes(url)) {
             chunk.assets.push(url)
-            if (id) {
-              unprocessedPreloads.delete(id)
-            }
           }
           if (!manifest[url]) {
             manifest[url] = {
@@ -165,7 +165,11 @@ export default defineNuxtModule<ModuleOptions>({
 
       // Source files in bundle
       for (const [id, urls] of fontMap) {
-        const chunk = manifest[relative(nuxt.options.srcDir, id)]
+        const path = relative(nuxt.options.srcDir, id)
+        // Style blocks are keyed by their module id, which carries a query
+        // (`?vue&type=style&index=0&lang.css`, plus `?inline&used` when inlining
+        // styles); the manifest is keyed by the component that owns them.
+        const chunk = manifest[path] || manifest[path.replace(/\?.*$/, '')]
         if (!chunk) continue
 
         addPreloadLinks(chunk, urls, id)

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -198,17 +198,17 @@ describe('features', () => {
     expect(extractPreloadLinks(html)).toContain('/custom-font.woff2')
   })
 
-  it('adds preload links to the HTML with global CSS', async () => {
+  it('does not add preload links for subsetted fonts in global CSS', async () => {
     const html = await $fetch<string>('/')
+    expect(extractPreloadLinks(html).sort()).toMatchInlineSnapshot(`[]`)
+  })
+
+  it('only preloads fonts used by the rendered route', async () => {
+    const html = await $fetch<string>('/providers/adobe')
     expect(extractPreloadLinks(html).sort()).toMatchInlineSnapshot(`
       [
-        "/_fonts/file.woff2",
-        "/_fonts/file.woff2",
-        "/_fonts/file.woff2",
-        "/_fonts/file.woff2",
-        "/_fonts/file.woff2",
-        "/custom-font.woff2",
-        "/some-font.woff2",
+        "/_fonts/aleo-400-italic.woff2",
+        "/_fonts/barlow-semi-condensed-400.woff2",
       ]
     `)
   })

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -108,22 +108,8 @@ function buildAssetLabels(...sources: string[]) {
   return labels
 }
 
-// Asset filenames are `<hash of remote filename>-<hash of source><extension>`, so
-// the same remote file reached via a differently-shaped source (e.g. relativised
-// against an emitted stylesheet) shares only its first hash. Fall back to that so
-// such assets are still identifiable.
 function label(file: string, labels: Map<string, string>) {
-  if (labels.has(file)) {
-    return labels.get(file)!
-  }
-  const prefix = file.slice(0, file.lastIndexOf('-'))
-  const extension = file.match(/\.[^.]+$/)?.[0] || ''
-  for (const [candidate, value] of labels) {
-    if (prefix && candidate.startsWith(prefix + '-')) {
-      return value
-    }
-  }
-  return `file${extension}`
+  return labels.get(file) || `file${file.match(/\.[^.]+$/)?.[0] || ''}`
 }
 
 function labelAssetURLs(css: string, labels: Map<string, string>) {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

we weren't properly accounting for the style query at the end of a component, meaning that every route ended up preloading these 'orphaned' fonts