### PR TITLE
fix: inline font faces from global stylesheets

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises'
-import { addBuildPlugin, addTemplate, defineNuxtModule } from '@nuxt/kit'
+import { addBuildPlugin, addServerPlugin, addTemplate, createResolver as createLocalResolver, defineNuxtModule, resolvePath } from '@nuxt/kit'
 import type { ResourceMeta } from 'vue-bundle-renderer'
 import { join, relative } from 'pathe'
 import { withoutLeadingSlash } from 'ufo'
@@ -108,6 +108,42 @@ export default defineNuxtModule<ModuleOptions>({
       return selectFontsToPreload(preload, fontFamily, fonts)
     }
 
+    // Nuxt's `inlineStyles` only inlines component styles by default, so `@font-face`
+    // rules that land in global stylesheets are served via `<link>` while the rest of the
+    // page's styles are inlined. We render those rules in the document head instead, and
+    // strip them from the bundled stylesheet.
+    const globalStylesheets = new Set<string>()
+    const hoistedFontFaces = new Set<string>()
+    let clientEntry: string | undefined
+
+    // Nuxt inlines global stylesheets itself when `inlineStyles` is enabled for the client
+    // entry, in which case their `@font-face` rules are already server-rendered.
+    const hoistsFontFaces = () => {
+      const inline = nuxt.options.features.inlineStyles
+      if (nuxt.options.dev || inline === false) {
+        return false
+      }
+      return typeof inline === 'function' ? !clientEntry || !inline(clientEntry) : inline !== true
+    }
+
+    nuxt.hook('modules:done', async () => {
+      for (const file of nuxt.options.css) {
+        globalStylesheets.add(await resolvePath(file))
+      }
+    })
+
+    if (!nuxt.options.dev && nuxt.options.features.inlineStyles !== false) {
+      const { resolve } = createLocalResolver(import.meta.url)
+      addServerPlugin(resolve('./runtime/nitro/inline-font-faces'))
+      nuxt.hook('nitro:config', (config) => {
+        config.virtual ||= {}
+        config.virtual['#nuxt-fonts-inline'] = () => {
+          const css = hoistsFontFaces() ? [...hoistedFontFaces].join('').replace(/\s*\n\s*/g, '') : ''
+          return `export const css = ${JSON.stringify(css)}`
+        }
+      })
+    }
+
     nuxt.options.css.push('#build/nuxt-fonts-global.css')
     addTemplate({
       filename: 'nuxt-fonts-global.css',
@@ -135,7 +171,9 @@ export default defineNuxtModule<ModuleOptions>({
             // We only inject basic `@font-face` as metrics for fallbacks don't make sense
             // in this context unless we provide a name for the user to use elsewhere as a
             // `font-family`.
-            css += generateFontFace(family.name, font) + '\n'
+            const fontFace = generateFontFace(family.name, font)
+            hoistedFontFaces.add(fontFace)
+            css += fontFace + '\n'
           }
         }
         return css
@@ -145,7 +183,8 @@ export default defineNuxtModule<ModuleOptions>({
     let viteEntry: string | undefined
     nuxt.hook('vite:extend', (ctx) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      viteEntry = relative(ctx.config.root || nuxt.options.srcDir, (ctx as any).entry)
+      clientEntry = (ctx as any).entry
+      viteEntry = relative(ctx.config.root || nuxt.options.srcDir, clientEntry!)
     })
     nuxt.hook('build:manifest', (manifest) => {
       const unprocessedPreloads = new Set([...fontMap.keys()])
@@ -205,6 +244,9 @@ export default defineNuxtModule<ModuleOptions>({
 
     addBuildPlugin(FontFamilyInjectionPlugin({
       dev: nuxt.options.dev,
+      hoistsFontFaces,
+      hoistedFontFaces,
+      isGlobalStylesheet: id => globalStylesheets.has(id),
       fontsToPreload: fontMap,
       processCSSVariables: options.experimental?.processCSSVariables ?? options.processCSSVariables,
       selectFontsToPreload: resolveFontsToPreload,

--- a/src/plugins/transform.ts
+++ b/src/plugins/transform.ts
@@ -4,9 +4,20 @@ import { transformCSS } from 'fontless'
 import type { FontFamilyInjectionPluginOptions } from 'fontless'
 
 const SKIP_RE = /\/node_modules\/vite-plugin-vue-inspector\//
+const FONT_FACE_RE = /@font-face\s*\{[^}]*\}/g
+const FONT_FAMILY_RE = /font-family:\s*(['"]?)((?:[^'";\\}]|\\.)*)\1/
+
+interface FontFamilyInjectionPluginNuxtOptions extends FontFamilyInjectionPluginOptions {
+  /** Whether `@font-face` rules from global stylesheets are rendered in the document head. */
+  hoistsFontFaces?: () => boolean
+  /** Whether a module id is one of the app's global stylesheets (`nuxt.options.css`). */
+  isGlobalStylesheet?: (id: string) => boolean
+  /** The `@font-face` rules to render in the document head. */
+  hoistedFontFaces?: Set<string>
+}
 
 // TODO: support shared chunks of CSS
-export const FontFamilyInjectionPlugin = (options: FontFamilyInjectionPluginOptions) => createUnplugin(() => {
+export const FontFamilyInjectionPlugin = (options: FontFamilyInjectionPluginNuxtOptions) => createUnplugin(() => {
   return {
     name: 'nuxt:fonts:font-family-injection',
     transform: {
@@ -24,6 +35,16 @@ export const FontFamilyInjectionPlugin = (options: FontFamilyInjectionPluginOpti
         const s = await transformCSS(options, code, id)
 
         if (s.hasChanged()) {
+          if (options.hoistedFontFaces && options.hoistsFontFaces?.() && options.isGlobalStylesheet?.(id.replace(/\?.*$/, ''))) {
+            // Rules authored in the stylesheet itself may use URLs relative to it, so only
+            // the rules we injected are safe to render elsewhere in the document.
+            const original = new Set(code.match(FONT_FACE_RE))
+            for (const rule of s.toString().match(FONT_FACE_RE) || []) {
+              if (!original.has(rule)) {
+                options.hoistedFontFaces.add(rule)
+              }
+            }
+          }
           return {
             code: s.toString(),
             map: s.generateMap({ hires: true }),
@@ -56,12 +77,17 @@ export const FontFamilyInjectionPlugin = (options: FontFamilyInjectionPluginOpti
       generateBundle: {
         enforce: 'post',
         async handler(_outputOptions, bundle) {
+          const hoistedFamilies = options.hoistsFontFaces?.() ? familiesOf(options.hoistedFontFaces) : new Set<string>()
+
           for (const key in bundle) {
             const chunk = bundle[key]!
             if (chunk?.type === 'asset' && isCSS(chunk.fileName)) {
               const s = await transformCSS(options, chunk.source.toString(), key, { relative: true })
               if (s.hasChanged()) {
                 chunk.source = s.toString()
+              }
+              if (hoistedFamilies.size > 0) {
+                chunk.source = stripFontFaces(chunk.source.toString(), hoistedFamilies)
               }
             }
           }
@@ -70,6 +96,24 @@ export const FontFamilyInjectionPlugin = (options: FontFamilyInjectionPluginOpti
     },
   }
 })
+
+function familiesOf(fontFaces: Set<string> | undefined) {
+  const families = new Set<string>()
+  for (const rule of fontFaces || []) {
+    const family = rule.match(FONT_FAMILY_RE)?.[2]
+    if (family) {
+      families.add(family)
+    }
+  }
+  return families
+}
+
+function stripFontFaces(code: string, families: Set<string>) {
+  return code.replace(FONT_FACE_RE, (rule) => {
+    const family = rule.match(FONT_FAMILY_RE)?.[2]
+    return family && families.has(family) ? '' : rule
+  })
+}
 
 // Copied from vue-bundle-renderer utils
 const IS_CSS_RE = /\.(?:css|scss|sass|postcss|pcss|less|stylus|styl)(?:\?[^.]+)?$/

--- a/src/runtime/nitro/inline-font-faces.ts
+++ b/src/runtime/nitro/inline-font-faces.ts
@@ -1,0 +1,12 @@
+// @ts-expect-error virtual file provided by `@nuxt/fonts`
+import { css } from '#nuxt-fonts-inline'
+
+import { defineNitroPlugin } from 'nitropack/runtime'
+
+export default defineNitroPlugin((nitro) => {
+  if (!css) return
+
+  nitro.hooks.hook('render:html', (html) => {
+    html.head.push(`<style>${css}</style>`)
+  })
+})

--- a/test/fixtures/global-css/assets/global.css
+++ b/test/fixtures/global-css/assets/global.css
@@ -1,0 +1,3 @@
+body {
+  font-family: 'MyCustom', sans-serif;
+}

--- a/test/fixtures/global-css/nuxt.config.ts
+++ b/test/fixtures/global-css/nuxt.config.ts
@@ -1,0 +1,11 @@
+export default defineNuxtConfig({
+  modules: ['../../../src/module'],
+  css: ['~/assets/global.css'],
+  compatibilityDate: '2024-08-19',
+  fonts: {
+    families: [
+      { name: 'MyCustom', src: '/custom-font.woff2' },
+      { name: 'CustomGlobal', global: true, src: '/custom-font.woff2' },
+    ],
+  },
+})

--- a/test/global-css.test.ts
+++ b/test/global-css.test.ts
@@ -1,0 +1,39 @@
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect } from 'vitest'
+import { setup, $fetch } from '@nuxt/test-utils'
+
+import { extractFontFaces } from './utils'
+
+await setup({
+  rootDir: fileURLToPath(new URL('./fixtures/global-css', import.meta.url)),
+})
+
+describe('global stylesheets', () => {
+  it('inlines font faces injected into stylesheets which Nuxt does not inline', async () => {
+    const html = await $fetch<string>('/')
+    expect(extractFontFaces('MyCustom', html)).toMatchInlineSnapshot(`
+      [
+        "@font-face{font-display:swap;font-family:MyCustom;src:url(/custom-font.woff2) format(woff2)}",
+      ]
+    `)
+  })
+
+  it('strips hoisted font faces from the bundled stylesheet', async () => {
+    const html = await $fetch<string>('/')
+    const stylesheets = Array.from(html.matchAll(/<link rel="stylesheet" href="([^"]+)"/g), m => m[1]!)
+    expect(stylesheets.length).toBeGreaterThan(0)
+    for (const stylesheet of stylesheets) {
+      const css = await $fetch<string>(stylesheet)
+      expect.soft(css).not.toContain('@font-face')
+    }
+  })
+
+  it('inlines font faces for globally registered families', async () => {
+    const html = await $fetch<string>('/')
+    expect(extractFontFaces('CustomGlobal', html)).toMatchInlineSnapshot(`
+      [
+        "@font-face {font-display: swap;font-family: 'CustomGlobal';src: url("/custom-font.woff2") format(woff2)}",
+      ]
+    `)
+  })
+})


### PR DESCRIPTION
resolves https://github.com/nuxt/fonts/issues/840

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

although it's true we don't generally inline global stylesheets, the font-faces nuxt/fonts generates are a good candidate for doing so because they help reduce layout shift. discovering them in a css file also can create a waterfall and impact performance negatively...