### PR TITLE
feat(local): support scanning font files from additional directories

### DIFF
--- a/docs/content/1.get-started/2.configuration.md
+++ b/docs/content/1.get-started/2.configuration.md
@@ -273,7 +273,7 @@ export default defineNuxtConfig({
 
 ## `provider`
 
-In some cases you may wish to use only one font provider. This is equivalent to disabling all other font providers.
+In some cases you may wish to use only one font provider. This is equivalent to disabling all other font providers, so a per-family `provider` other than the one configured here will not be used.
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({

--- a/docs/content/1.get-started/4.providers.md
+++ b/docs/content/1.get-started/4.providers.md
@@ -25,6 +25,37 @@ Files marked as variable without a range (`my-font-variable.woff2`, `my-font-vf.
 Please note that the local provider will only attempt to load styles and weights that were configured in the *Font Options*.
 ::
 
+#### Fonts installed from npm
+
+Some fonts are distributed as npm packages containing bare font files, with no stylesheet for the [`npm` provider](#npm) to read. If one of these is installed, it is scanned automatically and needs no configuration:
+
+```ts
+export default defineNuxtConfig({
+  modules: ['@nuxt/fonts'],
+  fonts: {
+    families: [
+      { name: 'Geist', provider: 'local' },
+    ],
+  }
+})
+```
+
+Filenames still drive weight, style and subset detection, so `Geist-Bold.woff2` resolves `font-family: Geist` at weight `700`. Matched fonts are emitted as build assets and served from your own origin.
+
+For a package that is not scanned automatically, add it with `packages`, or point at a directory directly with `dirs` (relative paths are resolved from your project root):
+
+```ts
+export default defineNuxtConfig({
+  modules: ['@nuxt/fonts'],
+  fonts: {
+    local: {
+      packages: ['my-font-package'],
+      dirs: ['assets/fonts'],
+    },
+  }
+})
+```
+
 ### `google`
 
 [Google Fonts](https://fonts.google.com/) is one of the best known public font APIs.
@@ -53,7 +84,13 @@ You should read their terms in full before using a font through `fontshare`.
 
 The npm provider resolves fonts from npm packages installed in your project's `node_modules`. It automatically detects known font packages (such as [`@fontsource/*`](https://fontsource.org/), [`@fontsource-variable/*`](https://fontsource.org/), and [`cal-sans`](https://github.com/calcom/font)) from your `package.json` dependencies and devDependencies.
 
-By default, fonts are resolved locally from disk (`remote: false`), so no CDN requests are made. This makes it a good choice for self-hosted fonts when you want to install font packages via npm and have them resolved at build time.
+By default the stylesheet shipped with the package is read from disk (`remote: false`) rather than from a CDN, but the font files it references are still fetched from the CDN at build time and served from your own origin.
+
+Only packages that ship a CSS entrypoint (such as `@fontsource/*` or `cal-sans`) can be used with this provider. Packages that ship bare font files are handled by the [`local` provider](#local) instead.
+
+::note{to="/get-started/configuration#provider"}
+Setting a top-level `provider` disables every other provider, including `npm`, so a per-family `provider: 'npm'` will not be used.
+::
 
 ```ts
 export default defineNuxtConfig({

--- a/playgrounds/basic/nuxt.config.ts
+++ b/playgrounds/basic/nuxt.config.ts
@@ -23,6 +23,7 @@ export default defineNuxtConfig({
       { name: 'Barlow', preload: true },
       { name: 'Roboto Mono', provider: 'fontsource' },
       { name: 'Roboto Flex', provider: 'fontsource' },
+      { name: 'CalSans', provider: 'local', weights: [600] },
     ],
     adobe: {
       id: ['sij5ufr', 'grx7wdj'],

--- a/playgrounds/basic/pages/providers/local-package.vue
+++ b/playgrounds/basic/pages/providers/local-package.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    Local font from an npm package
+  </div>
+</template>
+
+<style scoped>
+div {
+  font-family: 'CalSans', sans-serif;
+}
+</style>

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -1,5 +1,6 @@
 import fsp from 'node:fs/promises'
 import { writeFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import { addDevServerHandler, addVitePlugin, useNuxt } from '@nuxt/kit'
 import type { H3Event } from 'h3'
 import { eventHandler, createEvent, createError, setResponseHeader } from 'h3'
@@ -39,7 +40,7 @@ export async function setupPublicAssetStrategy(storage: Storage<StorageValue>, o
     // Use storage to cache the font data between requests
     let res = await storage.getItemRaw<Buffer>(key)
     if (!res) {
-      res = await $fetch(url, { responseType: 'arrayBuffer' }).then(b => Buffer.from(b))
+      res = await readFontData(url)
       await storage.setItemRaw(key, res)
     }
     // Set immutable cache headers to prevent font flashes during development
@@ -126,8 +127,7 @@ export async function setupPublicAssetStrategy(storage: Storage<StorageValue>, o
             logger.info('Downloading fonts...')
           }
           logger.log(colors.gray('  ├─ ' + url))
-          const r = await $fetch(url, { responseType: 'arrayBuffer' })
-          res = Buffer.from(r)
+          res = await readFontData(url)
           await storage.setItemRaw(key, res)
         }
         await fsp.writeFile(join(cacheDir, filename), res)
@@ -141,6 +141,13 @@ export async function setupPublicAssetStrategy(storage: Storage<StorageValue>, o
   return {
     normalizeFontData: normalizeFontData.bind(null, context),
   }
+}
+
+async function readFontData(url: string) {
+  if (url.startsWith('file://')) {
+    return await fsp.readFile(fileURLToPath(url))
+  }
+  return await $fetch(url, { responseType: 'arrayBuffer' }).then(b => Buffer.from(b))
 }
 
 const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365

--- a/src/module.ts
+++ b/src/module.ts
@@ -6,7 +6,7 @@ import { withoutLeadingSlash } from 'ufo'
 
 import defu from 'defu'
 import { createResolver, resolveProviders, defaultOptions, defaultValues, generateFontFace } from 'fontless'
-import type { Resolver } from 'fontless'
+import type { FontlessOptions, Resolver } from 'fontless'
 import type { FontFaceData } from 'unifont'
 import { createFontStorage } from './cache'
 import { FontFamilyInjectionPlugin } from './plugins/transform'
@@ -97,7 +97,7 @@ export default defineNuxtModule<ModuleOptions>({
         }
       }
 
-      resolvePromise = createResolver({ options, logger, providers, storage, exposeFont, normalizeFontData })
+      resolvePromise = createResolver({ options: options as FontlessOptions, logger, providers, storage, exposeFont, normalizeFontData })
     })
 
     const fontMap = new Map<string, Set<string>>()

--- a/src/providers/local.ts
+++ b/src/providers/local.ts
@@ -1,5 +1,8 @@
+import { existsSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+
 import { glob } from 'tinyglobby'
-import { join, extname, relative, resolve } from 'pathe'
+import { join, dirname, extname, relative, resolve } from 'pathe'
 import { filename } from 'pathe/utils'
 import { anyOf, createRegExp, not, wordBoundary } from 'magic-regexp'
 import { defineFontProvider } from 'unifont'
@@ -9,10 +12,38 @@ import type { FontFaceData, ResolveFontResult } from 'unifont'
 
 import { parseFont } from 'fontless'
 
-export default defineFontProvider('local', () => {
+export interface LocalProviderOptions {
+  /**
+   * Additional directories to scan for font files, in addition to your public asset directories.
+   *
+   * Relative paths are resolved from your project root, which means fonts distributed within an
+   * npm package can be used, for example `node_modules/geist/dist/fonts/geist-sans`.
+   *
+   * Fonts found in these directories are emitted as build assets rather than served from
+   * `public/`.
+   */
+  dirs?: string[]
+  /**
+   * npm packages to scan for font files, in addition to the packages that are scanned
+   * automatically when installed. Packages that are not installed are ignored.
+   */
+  packages?: string[]
+}
+
+/**
+ * Packages that ship font files without a stylesheet, so the `npm` provider has nothing to read.
+ * Scanned automatically when installed, so that fonts distributed this way need no configuration.
+ */
+const knownFontPackages = [
+  'geist',
+  'cal-sans',
+]
+
+export default defineFontProvider('local', (options: LocalProviderOptions = {}) => {
   const providerContext = {
     rootPaths: [] as string[],
     registry: {} as Record<string, string[]>,
+    emittedPaths: new Set<string>(),
   }
 
   const nuxt = useNuxt()
@@ -44,7 +75,12 @@ export default defineFontProvider('local', () => {
     const fonts = new Set<string>()
     for (const path of paths) {
       const base = providerContext.rootPaths.find(root => path.startsWith(root))
-      fonts.add(base ? withLeadingSlash(relative(base, path)) : path)
+      if (base) {
+        fonts.add(withLeadingSlash(relative(base, path)))
+      }
+      else {
+        fonts.add(providerContext.emittedPaths.has(path) ? pathToFileURL(path).href : path)
+      }
     }
 
     return [...fonts].sort((a, b) => {
@@ -66,6 +102,24 @@ export default defineFontProvider('local', () => {
       providerContext.rootPaths.push(withTrailingSlash(assetsDir.dir))
       for (const file of possibleFontFiles) {
         registerFont(file.replace(assetsDir.dir, join(assetsDir.dir, assetsDir.baseURL || '/')))
+      }
+    }
+
+    const dirs = [...options.dirs || []]
+
+    for (const name of [...knownFontPackages, ...options.packages || []]) {
+      const dir = resolvePackageDir(name, nuxt.options.rootDir)
+      if (dir) {
+        dirs.push(dir)
+      }
+    }
+
+    for (const dir of dirs) {
+      const cwd = resolve(nuxt.options.rootDir, dir)
+      const files = await glob(['**/*.{ttf,woff,woff2,eot,otf}'], { absolute: true, cwd })
+      for (const file of files) {
+        providerContext.emittedPaths.add(file)
+        registerFont(file)
       }
     }
 
@@ -153,6 +207,11 @@ function matchWeightRange(value: string) {
 
 const VARIABLE_RE = /(?:^|[\W_])(?:variable|vf)(?:$|[\W_])/i
 
+// e.g. `semibold` in a filename should resolve to the same slug as `semi-bold`
+const hyphenlessWeightMap: Record<string, string> = Object.fromEntries(
+  Object.values(weightMap).filter(w => w.includes('-')).map(w => [w.replace('-', ''), w]),
+)
+
 const weights = Object.entries(weightMap).flatMap(e => e).filter(r => r !== 'normal')
 const WEIGHT_RE = createRegExp(anyOf(...new Set([...weights, ...weights.map(w => w.replace('-', ''))])).groupedAs('weight').after(not.digit).before(not.digit.or(wordBoundary)), ['i'])
 
@@ -205,7 +264,7 @@ function generateSlugs(path: string) {
     ? variableWeightKeys(Number(range.groups!.min), Number(range.groups!.max))
     : VARIABLE_RE.test(name)
       ? variableWeightKeys(100, 900)
-      : [weightMap[weight!] || weight!]
+      : [weightMap[weight!] || hyphenlessWeightMap[weight!.toLowerCase()] || weight!]
 
   const slugs = new Set<string>()
 
@@ -221,6 +280,25 @@ function generateSlugs(path: string) {
   }
 
   return [...slugs]
+}
+
+/**
+ * Locate an installed package without importing it, so packages that do not export their
+ * `package.json` (or have no main entry at all) can still be found.
+ */
+function resolvePackageDir(name: string, rootDir: string) {
+  let dir = rootDir
+  while (true) {
+    const candidate = join(dir, 'node_modules', name)
+    if (existsSync(candidate)) {
+      return candidate
+    }
+    const parent = dirname(dir)
+    if (parent === dir) {
+      return
+    }
+    dir = parent
+  }
 }
 
 function fontFamilyToSlug(family: string) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,12 @@
 import type { Nuxt } from '@nuxt/schema'
 import type { FontFaceData as UnifontFontFaceData, ProviderFactory, ResolveFontOptions, ResolveFontResult } from 'unifont'
 import type { FontlessOptions, NormalizeFontDataContext } from 'fontless'
+import type { LocalProviderOptions } from './providers/local'
 
-export interface ModuleOptions extends FontlessOptions {
+export interface ModuleOptions extends Omit<FontlessOptions, 'local'> {
+  /** Options passed directly to the `local` font provider */
+  local?: LocalProviderOptions
+
   /**
    *  Enables support for Nuxt DevTools.
    *

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -117,6 +117,21 @@ describe('providers', async () => {
     `)
   })
 
+  it('generates inlined font face rules for fonts in `node_modules` scanned by the `local` provider', async () => {
+    const html = await $fetch<string>('/providers/local-package')
+    expect(extractFontFaces('CalSans', html)).toMatchInlineSnapshot(`
+      [
+        "@font-face{font-display:swap;font-family:CalSans;font-style:normal;font-weight:600;src:local(CalSans SemiBold),url(/_fonts/calsans-600.woff2) format(woff2),url(/_fonts/calsans-600.woff) format(woff),url(/_fonts/calsans-600.ttf) format(truetype)}",
+      ]
+    `)
+
+    const rule = html.match(/font-family:CalSans;[^}]+/)?.[0]
+    const url = rule?.match(/url\((\/_fonts\/[^)]+\.woff2)\)/)?.[1]
+    expect(url).toBeDefined()
+    const font = await $fetch<Blob>(url!, { responseType: 'blob' })
+    expect(font.size).toBeGreaterThan(0)
+  })
+
   it('should allow overriding providers with `none`', async () => {
     const html = await $fetch<string>('/providers/none')
     expect(extractFontFaces('Custom Font', html)).toMatchInlineSnapshot(`[]`)

--- a/test/providers/local.test.ts
+++ b/test/providers/local.test.ts
@@ -1,4 +1,4 @@
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import fsp from 'node:fs/promises'
 
 import type { Nitro, NitroOptions } from 'nitropack'
@@ -7,6 +7,7 @@ import { dirname, join } from 'pathe'
 import { createUnifont } from 'unifont'
 
 import localProvider from '../../src/providers/local'
+import type { LocalProviderOptions } from '../../src/providers/local'
 
 const mockUseNuxt = vi.hoisted(() => vi.fn())
 vi.mock('@nuxt/kit', () => ({
@@ -295,6 +296,72 @@ describe('local font provider', () => {
 
     await cleanup()
   })
+
+  it('should scan known font packages without configuration', async () => {
+    const cleanup = await createFixture('known-package', [
+      'node_modules/geist/dist/fonts/geist-sans/Geist-Bold.woff2',
+      'node_modules/cal-sans/fonts/webfonts/CalSans-SemiBold.woff2',
+    ])
+    const provider = await setupFixture([], { rootDir: join(fixturePath, 'known-package') })
+
+    expect(await provider.resolveFont('Geist', {
+      weights: ['bold'],
+      styles: ['normal'],
+      subsets: ['latin'],
+      formats: ['woff2'],
+    }).then(r => r.fonts.map(f => f.src))).toEqual([[{
+      format: 'woff2',
+      url: pathToFileURL(join(fixturePath, 'known-package/node_modules/geist/dist/fonts/geist-sans/Geist-Bold.woff2')).href,
+    }]])
+
+    expect(await provider.resolveFont('Cal Sans', {
+      weights: ['600'],
+      styles: ['normal'],
+      subsets: ['latin'],
+      formats: ['woff2'],
+    }).then(r => r.fonts)).toHaveLength(1)
+
+    await cleanup()
+  })
+
+  it('should ignore known font packages that are not installed', async () => {
+    const cleanup = await createFixture('no-package', ['public/MyFont-400.woff2'])
+    const provider = await setupFixture(['no-package/public'], { rootDir: join(fixturePath, 'no-package') })
+
+    expect(await provider.resolveFont('Geist', {
+      weights: ['bold'],
+      styles: ['normal'],
+      subsets: ['latin'],
+      formats: ['woff2'],
+    }).then(r => r.fonts)).toEqual([])
+
+    await cleanup()
+  })
+
+  it('should scan additional directories, including within `node_modules`', async () => {
+    const cleanup = await createFixture('npm-package', [
+      'node_modules/geist/dist/fonts/Geist-Bold.woff2',
+      'node_modules/geist/dist/fonts/Geist-Bold.ttf',
+    ])
+    const provider = await setupFixture([], {
+      rootDir: join(fixturePath, 'npm-package'),
+      providerOptions: { dirs: ['node_modules/geist/dist/fonts'] },
+    })
+    const fonts = await provider.resolveFont('Geist', {
+      weights: ['bold'],
+      styles: ['normal'],
+      subsets: ['latin'],
+      formats: ['woff2', 'woff', 'ttf', 'otf', 'eot'],
+    }).then(r => r.fonts)
+
+    expect(fonts).toHaveLength(1)
+    expect(fonts[0]!.src.map(s => 'url' in s ? s.url : s)).toEqual([
+      pathToFileURL(join(fixturePath, 'npm-package/node_modules/geist/dist/fonts/Geist-Bold.woff2')).href,
+      pathToFileURL(join(fixturePath, 'npm-package/node_modules/geist/dist/fonts/Geist-Bold.ttf')).href,
+    ])
+
+    await cleanup()
+  })
 })
 
 /** test utilities */
@@ -311,9 +378,16 @@ async function createFixture(slug: string, files: string[]) {
   return () => fsp.rm(join(fixturePath, slug), { recursive: true, force: true })
 }
 
-async function setupFixture(publicAssetDirs: string[]) {
+interface FixtureOptions extends Record<string, unknown> {
+  rootDir?: string
+  providerOptions?: LocalProviderOptions
+}
+
+async function setupFixture(publicAssetDirs: string[], opts: FixtureOptions = {}) {
+  const { providerOptions, ...nuxtOptions } = opts
   let promise: Promise<unknown>
   mockUseNuxt.mockImplementation(() => ({
+    options: { ...nuxtOptions, rootDir: opts.rootDir || fixturePath },
     hook: (event: string, callback: (nitro: Nitro) => Promise<unknown>) => {
       if (event === 'nitro:init') {
         promise = callback({
@@ -324,7 +398,7 @@ async function setupFixture(publicAssetDirs: string[]) {
       }
     },
   }))
-  const unifont = await createUnifont([localProvider()])
+  const unifont = await createUnifont([localProvider(providerOptions)])
   await promise!
   return unifont
 }


### PR DESCRIPTION
### 🔗 Linked issue

closes #126

### 📚 Description

some fonts distributed as npm packages have never really worked (for example, packages like `geist` which ship bare `.woff2` files and no CSS)...

if one of these packages is installed, we now scan it automatically and you don't have to configure anything:

```ts
fonts: {
  families: [{ name: 'Geist', provider: 'local' }],
}
```

two escape hatches: `local.packages` to name another package, and `local.dirs` for a directory that isn't in a package at all (relative to `rootDir`).