### PR TITLE
fix: deduplicate inlined `@font-face` rules in rendered html

### DIFF
--- a/docs/content/1.get-started/2.configuration.md
+++ b/docs/content/1.get-started/2.configuration.md
@@ -320,6 +320,26 @@ export default defineNuxtConfig({
 If you previously set `processCSSVariables` to `true` for Tailwind v4 support, it is no longer needed or recommended in v0.11.0 and later.
 ::
 
+## `throwOnError`
+
+Defines what happens when a font cannot be resolved from a provider, or a font file cannot be downloaded. It defaults to `false` while developing (so a flaky provider does not block you) and `true` when building (so you don't ship a build with missing fonts).
+
+Font metadata requests and font file downloads are both retried a few times with backoff before this applies, so it only takes effect for persistent failures.
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  modules: ['@nuxt/fonts'],
+  fonts: {
+    // continue the build with a warning instead of failing
+    throwOnError: false
+  }
+})
+```
+
+::tip
+If your builds fail intermittently with a `404` from `fonts.gstatic.com`, consider [caching font downloads between builds](/advanced#caching-fonts-between-builds) or switching to a provider with stable URLs, such as `bunny`.
+::
+
 ## `experimental`
 
 Defines whether to enable experimental features. All of them are `false` by default.

--- a/docs/content/1.get-started/5.upgrade.md
+++ b/docs/content/1.get-started/5.upgrade.md
@@ -15,6 +15,10 @@ Font metadata and downloaded font files are now cached in `node_modules/.cache/n
 
 Generated `@font-face` declarations were previously minified with esbuild unless you had opted into `css.lightningcss`. They are now always minified with lightningcss, so the exact serialisation of the CSS we inject may differ (for example `local(Font Name)` rather than `local("Font Name")`). This is cosmetic, but it will show up in snapshot tests.
 
+#### Font failures fail production builds
+
+[`throwOnError`](/get-started/configuration#throwonerror) now defaults to `true` outside of dev mode, so a font that cannot be resolved or downloaded (after retries) fails the build rather than producing a build with a missing font. Set `throwOnError: false` to restore the previous behaviour.
+
 ### New Features
 
 #### Preloading fonts by subset
@@ -52,10 +56,6 @@ export default defineNuxtConfig({
 ## Upgrading to v0.14
 
 ### Breaking Changes
-
-#### Font failures fail production builds
-
-[`throwOnError`](/get-started/configuration#throwonerror) now defaults to `true` outside of dev mode, so a font that cannot be resolved or downloaded (after retries) fails the build rather than producing a build with a missing font. Set `throwOnError: false` to restore the previous behaviour.
 
 #### Default font format is now `woff2` only
 

--- a/docs/content/1.get-started/5.upgrade.md
+++ b/docs/content/1.get-started/5.upgrade.md
@@ -53,6 +53,10 @@ export default defineNuxtConfig({
 
 ### Breaking Changes
 
+#### Font failures fail production builds
+
+[`throwOnError`](/get-started/configuration#throwonerror) now defaults to `true` outside of dev mode, so a font that cannot be resolved or downloaded (after retries) fails the build rather than producing a build with a missing font. Set `throwOnError: false` to restore the previous behaviour.
+
 #### Default font format is now `woff2` only
 
 Previously, font providers could return multiple formats (e.g., `woff2`, `woff`, `truetype`). The default behavior now only resolves `woff2` format fonts, which is universally supported in all modern browsers.

--- a/docs/content/1.get-started/5.upgrade.md
+++ b/docs/content/1.get-started/5.upgrade.md
@@ -17,7 +17,11 @@ Generated `@font-face` declarations were previously minified with esbuild unless
 
 #### Font failures fail production builds
 
-[`throwOnError`](/get-started/configuration#throwonerror) now defaults to `true` outside of dev mode, so a font that cannot be resolved or downloaded (after retries) fails the build rather than producing a build with a missing font. Set `throwOnError: false` to restore the previous behaviour.
+[`throwOnError`](/get-started/configuration#throwonerror) now defaults to `true` outside of dev mode, so rather than producing a build with a missing font, the build fails when a provider errors, when a font file cannot be downloaded after retries, or when you set `provider` on a family and that provider does not contain it.
+
+A family that cannot be found by any provider still warns rather than failing, as does an unknown provider name, so fonts you declare yourself in CSS are unaffected.
+
+Set `throwOnError: false` to restore the previous behaviour.
 
 ### New Features
 

--- a/docs/content/2.advanced.md
+++ b/docs/content/2.advanced.md
@@ -44,6 +44,27 @@ Nuxt Fonts processes all your CSS and does the following things automatically wh
 
 1. **Include fonts in build.** When you build your project, we'll copy across all the fonts used in your project so you don't need to make any external requests when loading your site. (Any that haven't already been cached in development are downloaded at build time.) Font file names are hashed and Nuxt will serve them with long-lived cache headers.
 
+## Caching fonts between builds
+
+Font metadata and downloaded font files are cached on disk in `node_modules/.cache/nuxt/fonts/meta`, relative to your project root. If you restore that directory in CI, no fonts are downloaded and no provider requests are made at all.
+
+```yaml [.github/workflows/build.yml]
+- uses: actions/cache@v4
+  with:
+    path: node_modules/.cache/nuxt/fonts
+    key: nuxt-fonts-${{ hashFiles('nuxt.config.ts') }}
+    restore-keys: nuxt-fonts-
+```
+
+A few things to check if the cache doesn't seem to take effect:
+
+- The cache step must run **after** you install dependencies. Some package managers remove unknown directories inside `node_modules`, which will delete a cache restored before install.
+- `actions/setup-node` with `cache: 'pnpm'` (or `npm`/`yarn`) caches the package manager store, not `node_modules`, so it does not cover fonts.
+- With an exact `key` and no `restore-keys`, a config change means a cache miss and a full re-download.
+- In Docker builds, `node_modules/.cache` lives inside the build container. You need a cache mount (`RUN --mount=type=cache,target=/app/node_modules/.cache`) or a persistent volume for it to survive.
+
+If a path inside `node_modules` is awkward to cache, move it with the [`cache`](/get-started/configuration#cache) option.
+
 ## Module Hooks
 
 Nuxt Fonts exposes hooks for module authors to extend functionality.

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -4,7 +4,6 @@ import { fileURLToPath } from 'node:url'
 import { addDevServerHandler, addVitePlugin, useNuxt } from '@nuxt/kit'
 import type { H3Event } from 'h3'
 import { eventHandler, createEvent, createError, setResponseHeader } from 'h3'
-import { $fetch } from 'ofetch'
 import { colors } from 'consola/utils'
 import { defu } from 'defu'
 import type { NitroConfig } from 'nitropack'
@@ -14,11 +13,17 @@ import { join } from 'pathe'
 import { normalizeFontData } from 'fontless'
 import type { NormalizeFontDataContext } from 'fontless'
 import type { Storage, StorageValue } from 'unstorage'
+import { downloadFont } from './download'
 import { logger } from './logger'
 import type { ModuleOptions } from './types'
 
+interface PublicAssetStrategyOptions {
+  /** Whether a font that cannot be downloaded should fail the build. */
+  throwOnError?: boolean
+}
+
 // TODO: replace this with nuxt/assets when it is released
-export async function setupPublicAssetStrategy(storage: Storage<StorageValue>, options: ModuleOptions['assets'] = {}) {
+export async function setupPublicAssetStrategy(storage: Storage<StorageValue>, options: ModuleOptions['assets'] = {}, { throwOnError = true }: PublicAssetStrategyOptions = {}) {
   const nuxt = useNuxt()
 
   const context: NormalizeFontDataContext = {
@@ -127,7 +132,16 @@ export async function setupPublicAssetStrategy(storage: Storage<StorageValue>, o
             logger.info('Downloading fonts...')
           }
           logger.log(colors.gray('  ├─ ' + url))
-          res = await readFontData(url)
+          try {
+            res = await readFontData(url)
+          }
+          catch (error) {
+            if (throwOnError) {
+              throw error
+            }
+            logger.warn(`${(error as Error).message} This font will be missing from your build. Set \`fonts.throwOnError\` to \`true\` to fail the build instead.`)
+            continue
+          }
           await storage.setItemRaw(key, res)
         }
         await fsp.writeFile(join(cacheDir, filename), res)
@@ -147,7 +161,7 @@ async function readFontData(url: string) {
   if (url.startsWith('file://')) {
     return await fsp.readFile(fileURLToPath(url))
   }
-  return await $fetch(url, { responseType: 'arrayBuffer' }).then(b => Buffer.from(b))
+  return await downloadFont(url)
 }
 
 const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365

--- a/src/download.ts
+++ b/src/download.ts
@@ -14,6 +14,9 @@ export interface DownloadFontOptions {
  * Every failure is retried, including `404`s: Google's CSS edges hand out `woff2` URLs
  * that the file edges have not caught up with yet (nuxt/fonts#864), so a `404` here is
  * not reliably deterministic.
+ *
+ * `ofetch` retries eligible `GET` failures once by default, with no delay, which would
+ * both double the request count and bypass the backoff below.
  */
 export async function downloadFont(url: string, options: DownloadFontOptions = {}): Promise<Buffer> {
   const retries = options.retries ?? 3
@@ -21,7 +24,7 @@ export async function downloadFont(url: string, options: DownloadFontOptions = {
 
   for (let attempt = 0; ; attempt++) {
     try {
-      return Buffer.from(await $fetch(url, { responseType: 'arrayBuffer' }))
+      return Buffer.from(await $fetch(url, { responseType: 'arrayBuffer', retry: false }))
     }
     catch (cause) {
       if (attempt >= retries) {

--- a/src/download.ts
+++ b/src/download.ts
@@ -1,0 +1,35 @@
+import { $fetch } from 'ofetch'
+import { logger } from './logger'
+
+export interface DownloadFontOptions {
+  /** @default 3 */
+  retries?: number
+  /** @default 500 */
+  retryDelay?: number
+}
+
+/**
+ * Download a font file, retrying transient upstream failures with exponential backoff.
+ *
+ * Every failure is retried, including `404`s: Google's CSS edges hand out `woff2` URLs
+ * that the file edges have not caught up with yet (nuxt/fonts#864), so a `404` here is
+ * not reliably deterministic.
+ */
+export async function downloadFont(url: string, options: DownloadFontOptions = {}): Promise<Buffer> {
+  const retries = options.retries ?? 3
+  const retryDelay = options.retryDelay ?? 500
+
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return Buffer.from(await $fetch(url, { responseType: 'arrayBuffer' }))
+    }
+    catch (cause) {
+      if (attempt >= retries) {
+        throw new Error(`Could not download font from \`${url}\` after ${retries + 1} attempts.`, { cause })
+      }
+      const delay = retryDelay * 2 ** attempt
+      logger.warn(`Could not download font from \`${url}\`. Will retry in \`${delay}ms\`. \`${retries - attempt}\` retries left.`)
+      await new Promise(resolve => setTimeout(resolve, delay))
+    }
+  }
+}

--- a/src/module.ts
+++ b/src/module.ts
@@ -80,7 +80,11 @@ export default defineNuxtModule<ModuleOptions>({
 
     const storage = createFontStorage(options.cache, nuxt.options.rootDir)
 
-    const { normalizeFontData } = await setupPublicAssetStrategy(storage, options.assets)
+    // A missing font in a production build is worse than a failed build, but in dev we
+    // keep going so a flaky provider does not block work.
+    options.throwOnError ??= !nuxt.options.dev
+
+    const { normalizeFontData } = await setupPublicAssetStrategy(storage, options.assets, { throwOnError: options.throwOnError })
     const { exposeFont } = setupDevtoolsConnection(nuxt.options.dev && !!options.devtools)
 
     let resolveFontFaceWithOverride: Resolver

--- a/src/runtime/nitro/inline-font-faces.ts
+++ b/src/runtime/nitro/inline-font-faces.ts
@@ -3,10 +3,24 @@ import { css } from '#nuxt-fonts-inline'
 
 import { defineNitroPlugin } from 'nitropack/runtime'
 
-export default defineNitroPlugin((nitro) => {
-  if (!css) return
+const STYLE_RE = /<style[^>]*>([\s\S]*?)<\/style>/g
+const FONT_FACE_RE = /@font-face\s*\{[^}]*\}/g
 
+export default defineNitroPlugin((nitro) => {
   nitro.hooks.hook('render:html', (html) => {
-    html.head.push(`<style>${css}</style>`)
+    if (css) {
+      html.head.push(`<style>${css}</style>`)
+    }
+
+    const seen = new Set<string>()
+    for (let i = 0; i < html.head.length; i++) {
+      html.head[i] = html.head[i]!.replace(STYLE_RE, style => style.replace(FONT_FACE_RE, (rule) => {
+        if (seen.has(rule)) {
+          return ''
+        }
+        seen.add(rule)
+        return rule
+      }))
+    }
   })
 })

--- a/src/runtime/nitro/inline-font-faces.ts
+++ b/src/runtime/nitro/inline-font-faces.ts
@@ -6,6 +6,23 @@ import { defineNitroPlugin } from 'nitropack/runtime'
 const STYLE_RE = /<style[^>]*>([\s\S]*?)<\/style>/g
 const FONT_FACE_RE = /@font-face\s*\{[^}]*\}/g
 
+/**
+ * A rule nested in an at-rule (`@media`, `@supports`) only applies in that context, so it
+ * is not interchangeable with an identical rule at the top level.
+ */
+function isTopLevel(style: string, index: number) {
+  let depth = 0
+  for (let i = 0; i < index; i++) {
+    if (style[i] === '{') {
+      depth++
+    }
+    else if (style[i] === '}') {
+      depth--
+    }
+  }
+  return depth === 0
+}
+
 export default defineNitroPlugin((nitro) => {
   nitro.hooks.hook('render:html', (html) => {
     if (css) {
@@ -14,7 +31,10 @@ export default defineNitroPlugin((nitro) => {
 
     const seen = new Set<string>()
     for (let i = 0; i < html.head.length; i++) {
-      html.head[i] = html.head[i]!.replace(STYLE_RE, style => style.replace(FONT_FACE_RE, (rule) => {
+      html.head[i] = html.head[i]!.replace(STYLE_RE, style => style.replace(FONT_FACE_RE, (rule, index: number) => {
+        if (!isTopLevel(style, index)) {
+          return rule
+        }
         if (seen.has(rule)) {
           return ''
         }

--- a/test/download.test.ts
+++ b/test/download.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const fetchMock = vi.hoisted(() => vi.fn())
+
+vi.mock('ofetch', () => ({ $fetch: fetchMock }))
+vi.mock('../src/logger', () => ({ logger: { warn: vi.fn() } }))
+
+const { downloadFont } = await import('../src/download')
+
+describe('downloadFont', () => {
+  beforeEach(() => {
+    fetchMock.mockReset()
+  })
+
+  it('should return the font body on first success', async () => {
+    fetchMock.mockResolvedValueOnce(new TextEncoder().encode('font').buffer)
+
+    const res = await downloadFont('https://fonts.example/font.woff2', { retryDelay: 0 })
+
+    expect(res.toString()).toBe('font')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('should retry a transient 404 from the font CDN', async () => {
+    fetchMock
+      .mockRejectedValueOnce(Object.assign(new Error('404 Not Found'), { status: 404 }))
+      .mockResolvedValueOnce(new TextEncoder().encode('font').buffer)
+
+    const res = await downloadFont('https://fonts.example/font.woff2', { retryDelay: 0 })
+
+    expect(res.toString()).toBe('font')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('should throw an actionable error once retries are exhausted', async () => {
+    fetchMock.mockRejectedValue(new Error('fetch failed'))
+
+    await expect(downloadFont('https://fonts.example/font.woff2', { retries: 2, retryDelay: 0 }))
+      .rejects.toThrowError('Could not download font from `https://fonts.example/font.woff2` after 3 attempts.')
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+})

--- a/test/download.test.ts
+++ b/test/download.test.ts
@@ -19,6 +19,7 @@ describe('downloadFont', () => {
 
     expect(res.toString()).toBe('font')
     expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]![1]).toMatchObject({ retry: false })
   })
 
   it('should retry a transient 404 from the font CDN', async () => {

--- a/test/fixtures/global-css/app.vue
+++ b/test/fixtures/global-css/app.vue
@@ -1,0 +1,12 @@
+<template>
+  <div class="parent">
+    Hello
+    <ChildText />
+  </div>
+</template>
+
+<style scoped>
+.parent {
+  font-family: 'MyCustom', sans-serif;
+}
+</style>

--- a/test/fixtures/global-css/components/ChildText.vue
+++ b/test/fixtures/global-css/components/ChildText.vue
@@ -1,0 +1,11 @@
+<template>
+  <p class="child">
+    Child
+  </p>
+</template>
+
+<style scoped>
+.child {
+  font-family: 'MyCustom', sans-serif;
+}
+</style>

--- a/test/global-css.test.ts
+++ b/test/global-css.test.ts
@@ -28,6 +28,13 @@ describe('global stylesheets', () => {
     }
   })
 
+  it('does not repeat the same font face across inlined stylesheets', async () => {
+    const html = await $fetch<string>('/')
+    const rules = html.match(/@font-face\s*\{[^}]*\}/g) || []
+    expect(rules.length).toBeGreaterThan(0)
+    expect(rules).toStrictEqual([...new Set(rules)])
+  })
+
   it('inlines font faces for globally registered families', async () => {
     const html = await $fetch<string>('/')
     expect(extractFontFaces('CustomGlobal', html)).toMatchInlineSnapshot(`

--- a/test/global-css.test.ts
+++ b/test/global-css.test.ts
@@ -30,9 +30,7 @@ describe('global stylesheets', () => {
 
   it('does not repeat the same font face across inlined stylesheets', async () => {
     const html = await $fetch<string>('/')
-    const rules = html.match(/@font-face\s*\{[^}]*\}/g) || []
-    expect(rules.length).toBeGreaterThan(0)
-    expect(rules).toStrictEqual([...new Set(rules)])
+    expect(extractFontFaces('MyCustom', html)).toHaveLength(1)
   })
 
   it('inlines font faces for globally registered families', async () => {

--- a/test/inline-font-faces.test.ts
+++ b/test/inline-font-faces.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('#nuxt-fonts-inline', () => ({ css: '' }))
+vi.mock('nitropack/runtime', () => ({ defineNitroPlugin: (plugin: unknown) => plugin }))
+
+const { default: plugin } = await import('../src/runtime/nitro/inline-font-faces')
+
+function render(head: string[]) {
+  let hook: (html: { head: string[] }) => void
+  ;(plugin as (nitro: unknown) => void)({
+    hooks: { hook: (_: string, cb: typeof hook) => { hook = cb } },
+  })
+  const html = { head }
+  hook!(html)
+  return html.head
+}
+
+const rule = '@font-face{font-family:MyCustom;src:url(/_fonts/custom.woff2) format(woff2)}'
+
+describe('inline font faces', () => {
+  it('should remove a repeated font face from a later stylesheet', () => {
+    expect(render([`<style>${rule}</style>`, `<style>${rule}a{color:red}</style>`])).toEqual([
+      `<style>${rule}</style>`,
+      '<style>a{color:red}</style>',
+    ])
+  })
+
+  it('should keep a font face that only applies within an at-rule', () => {
+    const head = render([`<style>${rule}</style>`, `<style>@media print{${rule}}</style>`])
+    expect(head[1]).toBe(`<style>@media print{${rule}}</style>`)
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

closes #770
closes #840

### 📚 Description

currently we inject the `@font-face` into every stylesheet that mentions the family, and nuxt inlines component styles into `<style>` while serving global CSS via `<link>`, so the same rule can land in a document two or three times.

this drops identical `@font-face` rules across the inlined styles at render time (on top of #875, which moved the global ones into the head).

> [!TIP]
> `features: { inlineStyles: false }` shouldn't be needed as a workaround any more.