### PR TITLE
fix: add hint for missing local font files

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -17,6 +17,7 @@ import type { ModuleHooks, ModuleOptions } from './types'
 import { setupDevtoolsConnection } from './devtools'
 import { toUnifontProvider } from './utils'
 import local from './providers/local'
+import { withLocalProviderHintLogger } from './provider-hints'
 
 // extractable
 
@@ -79,6 +80,7 @@ export default defineNuxtModule<ModuleOptions>({
     const _providers = resolveProviders(options.providers, { root: nuxt.options.rootDir, alias: nuxt.options.alias })
 
     const storage = createFontStorage(options.cache, nuxt.options.rootDir)
+    const fontlessLogger = withLocalProviderHintLogger(logger)
 
     const { normalizeFontData } = await setupPublicAssetStrategy(storage, options.assets)
     const { exposeFont } = setupDevtoolsConnection(nuxt.options.dev && !!options.devtools)
@@ -97,7 +99,7 @@ export default defineNuxtModule<ModuleOptions>({
         }
       }
 
-      resolvePromise = createResolver({ options: options as FontlessOptions, logger, providers, storage, exposeFont, normalizeFontData })
+      resolvePromise = createResolver({ options: options as FontlessOptions, logger: fontlessLogger, providers, storage, exposeFont, normalizeFontData })
     })
 
     const fontMap = new Map<string, Set<string>>()

--- a/src/provider-hints.ts
+++ b/src/provider-hints.ts
@@ -1,0 +1,35 @@
+import type { ConsolaInstance } from 'consola'
+
+const LOCAL_PROVIDER_MISSING_FONT_RE = /^Could not produce font face declaration from `?local`? for font family `?(.+?)`?\.$/
+const LOCAL_FONT_EXTENSIONS = ['woff2', 'woff', 'ttf', 'otf', 'eot']
+
+export function withLocalProviderMissingFontHint(message: string) {
+  const match = message.match(LOCAL_PROVIDER_MISSING_FONT_RE)
+  if (!match) {
+    return message
+  }
+
+  const fileStem = fontFamilyToFileStem(match[1]!)
+  if (!fileStem) {
+    return message
+  }
+
+  return `${message} Expected a file like \`${fileStem}.[${LOCAL_FONT_EXTENSIONS.join('|')}]\` in a configured public asset directory or local provider dir.`
+}
+
+export function withLocalProviderHintLogger(logger: ConsolaInstance): ConsolaInstance {
+  return Object.assign(Object.create(logger), {
+    warn(message: unknown, ...args: unknown[]) {
+      return logger.warn(typeof message === 'string' ? withLocalProviderMissingFontHint(message) : message, ...args)
+    },
+  }) as ConsolaInstance
+}
+
+function fontFamilyToFileStem(family: string) {
+  return family
+    .trim()
+    .toLowerCase()
+    .replace(/['"]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}

--- a/src/provider-hints.ts
+++ b/src/provider-hints.ts
@@ -3,6 +3,7 @@ import type { ConsolaInstance } from 'consola'
 const LOCAL_PROVIDER_MISSING_FONT_RE = /^Could not produce font face declaration from `?local`? for font family `?(.+?)`?\.$/
 const LOCAL_FONT_EXTENSIONS = ['woff2', 'woff', 'ttf', 'otf', 'eot']
 
+/** Append an expected local-font filename to matching resolver warnings. */
 export function withLocalProviderMissingFontHint(message: string) {
   const match = message.match(LOCAL_PROVIDER_MISSING_FONT_RE)
   if (!match) {
@@ -17,14 +18,17 @@ export function withLocalProviderMissingFontHint(message: string) {
   return `${message} Expected a file like \`${fileStem}.[${LOCAL_FONT_EXTENSIONS.join('|')}]\` in a configured public asset directory or local provider dir.`
 }
 
+/** Return a logger that enriches local-provider missing-font warnings. */
 export function withLocalProviderHintLogger(logger: ConsolaInstance): ConsolaInstance {
   return Object.assign(Object.create(logger), {
+    /** Forward warnings after enhancing matching string messages. */
     warn(message: unknown, ...args: unknown[]) {
       return logger.warn(typeof message === 'string' ? withLocalProviderMissingFontHint(message) : message, ...args)
     },
   }) as ConsolaInstance
 }
 
+/** Convert a font-family name into the filename stem used by local font assets. */
 function fontFamilyToFileStem(family: string) {
   return family
     .trim()

--- a/test/provider-hints.test.ts
+++ b/test/provider-hints.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { withLocalProviderHintLogger, withLocalProviderMissingFontHint } from '../src/provider-hints'
+
+describe('provider hints', () => {
+  it('adds an expected file hint to local provider missing-font warnings', () => {
+    expect(withLocalProviderMissingFontHint('Could not produce font face declaration from `local` for font family `Faro Variable`.'))
+      .toBe('Could not produce font face declaration from `local` for font family `Faro Variable`. Expected a file like `faro-variable.[woff2|woff|ttf|otf|eot]` in a configured public asset directory or local provider dir.')
+  })
+
+  it('leaves unrelated warnings unchanged', () => {
+    expect(withLocalProviderMissingFontHint('Unknown provider `other` for font family `Faro Variable`. Falling back to default providers.'))
+      .toBe('Unknown provider `other` for font family `Faro Variable`. Falling back to default providers.')
+  })
+
+  it('wraps logger warnings without changing non-string arguments', () => {
+    const warn = vi.fn()
+    const logger = withLocalProviderHintLogger({ warn } as any)
+    const error = new Error('failure')
+
+    logger.warn('Could not produce font face declaration from `local` for font family `Faro Variable`.', error)
+    logger.warn(error)
+
+    expect(warn).toHaveBeenNthCalledWith(1, 'Could not produce font face declaration from `local` for font family `Faro Variable`. Expected a file like `faro-variable.[woff2|woff|ttf|otf|eot]` in a configured public asset directory or local provider dir.', error)
+    expect(warn).toHaveBeenNthCalledWith(2, error)
+  })
+})


### PR DESCRIPTION
### Summary
- add a local-provider warning hint with an example expected font filename pattern
- wrap the fontless logger so only missing local provider font warnings are augmented
- add focused coverage for the hint formatting and logger wrapper

Fixes #791.

### Tests
- pnpm vitest run test/provider-hints.test.ts
- pnpm vitest run test/parse.test.ts test/providers/local.test.ts test/provider-hints.test.ts
- pnpm lint
- pnpm test:types