### PR TITLE
feat(deps)!: update `fontless` and `unifont`

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@nuxt/kit": "^4.5.2",
     "consola": "^3.4.2",
     "defu": "^6.1.7",
-    "fontless": "^0.3.0",
+    "fontless": "^0.4.0",
     "h3": "^1.15.11",
     "magic-regexp": "^0.11.0",
     "ofetch": "^1.5.1",
@@ -58,7 +58,7 @@
     "sirv": "^3.0.2",
     "tinyglobby": "^0.2.17",
     "ufo": "^1.6.4",
-    "unifont": "^0.7.5",
+    "unifont": "^0.8.1",
     "unplugin": "^3.3.0",
     "unstorage": "^1.17.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: ^6.1.7
         version: 6.1.7
       fontless:
-        specifier: ^0.3.0
-        version: 0.3.0(db0@0.3.4(better-sqlite3@12.11.1))(esbuild@0.28.2)(ioredis@5.11.1(supports-color@10.2.2))(postcss@8.5.26)(rolldown@1.2.5)(rollup@4.62.5)(vite@8.2.2)(webpack@5.109.2(cssnano@8.0.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+        specifier: ^0.4.0
+        version: 0.4.0(db0@0.3.4(better-sqlite3@12.11.1))(esbuild@0.28.2)(ioredis@5.11.1(supports-color@10.2.2))(postcss@8.5.26)(rolldown@1.2.5)(rollup@4.62.5)(vite@8.2.2)(webpack@5.109.2(cssnano@8.0.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       h3:
         specifier: ^1.15.11
         version: 1.15.11
@@ -64,8 +64,8 @@ importers:
         specifier: ^1.6.4
         version: 1.6.4
       unifont:
-        specifier: ^0.7.5
-        version: 0.7.5
+        specifier: ^0.8.1
+        version: 0.8.1
       unplugin:
         specifier: ^3.3.0
         version: 3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.5)(vite@8.2.2)(webpack@5.109.2(cssnano@8.0.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
@@ -195,7 +195,7 @@ importers:
         version: 12.11.1
       docus:
         specifier: ^5.12.3
-        version: 5.12.3(7d2a4f67b9a8d28f0ebe142e521d3a05)
+        version: 5.12.3(0e67b8363a3736329708d5747662a9f7)
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -5189,8 +5189,8 @@ packages:
     resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
     engines: {node: '>=20'}
 
-  fontless@0.3.0:
-    resolution: {integrity: sha512-gFFCzRzmUJIaUUzAgBGHn4e7CNiTUEDdKtzUvnFAuLL7IrcHU2GY5K/7upCqMKdW4bInLKiWyBZ8orzfOt5vdw==}
+  fontless@0.4.0:
+    resolution: {integrity: sha512-s579YVgJJk0d49WQaWBj4YSflOg3qFF78/y0dCNbCgIsGhoSnnr1p1Vrgrj5Vj12fTZMk8KBJI9cZ27eOUEXww==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ~8.2.2
@@ -7997,8 +7997,8 @@ packages:
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
-  unifont@0.7.5:
-    resolution: {integrity: sha512-ULe/Cs+ZIsq+dcFofNkhqielCrUJnb5mr+Yc4EBM2VlL+6OZR6+cjtI2mT1bJvRBrVncqHAbLURxmPLcCXzWMg==}
+  unifont@0.8.1:
+    resolution: {integrity: sha512-ePAkMC5/UT/DnM7xiFCvsAxtFdBn/BD6DciPoY6ZzDP9iaIsZmFgBVzoPtX1zOUKtQdBL3JH7voTnogcWVTqYA==}
 
   unimport@6.4.0:
     resolution: {integrity: sha512-JJOOuNMFq8b4ZPBKwQUxEcba4MplskDzYI1Lvrf8rJfWphZTWvPNXWa493qsPngHUmub89w6C7j+SeLWTE/UIQ==}
@@ -14352,7 +14352,7 @@ snapshots:
 
   diff@8.0.4: {}
 
-  docus@5.12.3(7d2a4f67b9a8d28f0ebe142e521d3a05):
+  docus@5.12.3(0e67b8363a3736329708d5747662a9f7):
     dependencies:
       '@ai-sdk/gateway': 3.0.177(zod@4.4.3)
       '@ai-sdk/mcp': 1.0.71(zod@4.4.3)
@@ -14384,7 +14384,7 @@ snapshots:
       motion-v: 2.4.0(@vueuse/core@14.4.0(vue@3.5.41(typescript@6.0.3)))(vue@3.5.41(typescript@6.0.3))
       nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.146.0)(@parcel/watcher@2.6.0)(@types/node@24.13.3)(@vitejs/devtools@0.5.2)(@vue/compiler-sfc@3.5.41)(better-sqlite3@12.11.1)(cac@7.0.0)(db0@0.3.4(better-sqlite3@12.11.1))(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.135.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.5)(rollup@4.62.5))(rollup@4.62.5)(sass@1.103.1)(srvx@0.12.7)(supports-color@10.2.2)(terser@5.50.0)(typescript@6.0.3)(vite@8.2.2)(vue-tsc@3.3.10(typescript@6.0.3))(webpack@5.109.2(cssnano@8.0.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))(yaml@2.9.0)
       nuxt-llms: 0.2.0(magic-string@1.2.2)(magicast@0.5.4)(oxc-parser@0.135.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.5)(vite@8.2.2)(webpack@5.109.2(cssnano@8.0.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
-      nuxt-og-image: 6.6.0(b6f23b0d9e491e6a3a4c54dd4e181c0a)
+      nuxt-og-image: 6.6.0(1e8582449634a9bd22738b9f52054b6d)
       pathe: 2.0.3
       pkg-types: 2.3.1
       scule: 1.3.0
@@ -15143,11 +15143,12 @@ snapshots:
     dependencies:
       tiny-inflate: 1.0.3
 
-  fontless@0.3.0(db0@0.3.4(better-sqlite3@12.11.1))(esbuild@0.28.2)(ioredis@5.11.1(supports-color@10.2.2))(postcss@8.5.26)(rolldown@1.2.5)(rollup@4.62.5)(vite@8.2.2)(webpack@5.109.2(cssnano@8.0.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)):
+  fontless@0.4.0(db0@0.3.4(better-sqlite3@12.11.1))(esbuild@0.28.2)(ioredis@5.11.1(supports-color@10.2.2))(postcss@8.5.26)(rolldown@1.2.5)(rollup@4.62.5)(vite@8.2.2)(webpack@5.109.2(cssnano@8.0.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)):
     dependencies:
       consola: 3.4.2
       css-tree: 3.2.1
       defu: 6.1.7
+      exsolve: 1.1.1
       fontaine: 0.8.1(esbuild@0.28.2)(postcss@8.5.26)(rolldown@1.2.5)(rollup@4.62.5)(vite@8.2.2)(webpack@5.109.2(cssnano@8.0.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       jiti: 2.7.0
       lightningcss: 1.33.0
@@ -15155,7 +15156,7 @@ snapshots:
       ohash: 2.0.12
       pathe: 2.0.3
       ufo: 1.6.4
-      unifont: 0.7.5
+      unifont: 0.8.1
       unstorage: 1.17.5(db0@0.3.4(better-sqlite3@12.11.1))(ioredis@5.11.1(supports-color@10.2.2))
     optionalDependencies:
       vite: 8.2.2(@types/node@24.13.3)(@vitejs/devtools@0.5.2)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(terser@5.50.0)(yaml@2.9.0)
@@ -17087,7 +17088,7 @@ snapshots:
       - rolldown
       - unplugin
 
-  nuxt-og-image@6.6.0(b6f23b0d9e491e6a3a4c54dd4e181c0a):
+  nuxt-og-image@6.6.0(1e8582449634a9bd22738b9f52054b6d):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/kit': 4.5.2(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.135.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.5)(vite@8.2.2)(webpack@5.109.2(cssnano@8.0.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
@@ -17125,11 +17126,11 @@ snapshots:
       unstorage: 1.17.5(db0@0.3.4(better-sqlite3@12.11.1))(ioredis@5.11.1(supports-color@10.2.2))
     optionalDependencies:
       '@takumi-rs/core': 1.8.7
-      fontless: 0.3.0(db0@0.3.4(better-sqlite3@12.11.1))(esbuild@0.28.2)(ioredis@5.11.1(supports-color@10.2.2))(postcss@8.5.26)(rolldown@1.2.5)(rollup@4.62.5)(vite@8.2.2)(webpack@5.109.2(cssnano@8.0.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      fontless: 0.4.0(db0@0.3.4(better-sqlite3@12.11.1))(esbuild@0.28.2)(ioredis@5.11.1(supports-color@10.2.2))(postcss@8.5.26)(rolldown@1.2.5)(rollup@4.62.5)(vite@8.2.2)(webpack@5.109.2(cssnano@8.0.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       nitropack: 2.13.4(@parcel/watcher@2.6.0)(better-sqlite3@12.11.1)(oxc-parser@0.135.0)(rolldown@1.2.5)(srvx@0.12.7)(supports-color@10.2.2)(vite@8.2.2)(webpack@5.109.2(cssnano@8.0.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       playwright-core: 1.62.1
       tailwindcss: 4.3.3
-      unifont: 0.7.5
+      unifont: 0.8.1
       zod: 4.4.3
     transitivePeerDependencies:
       - '@farmfe/core'
@@ -19666,10 +19667,11 @@ snapshots:
       trough: 2.2.0
       vfile: 6.0.3
 
-  unifont@0.7.5:
+  unifont@0.8.1:
     dependencies:
       css-tree: 3.2.1
       ohash: 2.0.12
+      std-env: 4.2.0
       undici: 8.10.0
 
   unimport@6.4.0(esbuild@0.28.2)(oxc-parser@0.131.0)(rolldown@1.2.5)(rollup@4.62.5)(vite@8.2.2)(webpack@5.109.2(cssnano@8.0.7(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)):

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -11,7 +11,7 @@ import { joinURL } from 'ufo'
 import { join } from 'pathe'
 
 import { normalizeFontData } from 'fontless'
-import type { NormalizeFontDataContext } from 'fontless'
+import type { NormalizeFontDataContext, RenderedFont } from 'fontless'
 import type { Storage, StorageValue } from 'unstorage'
 import { downloadFont } from './download'
 import { logger } from './logger'
@@ -28,24 +28,25 @@ export async function setupPublicAssetStrategy(storage: Storage<StorageValue>, o
 
   const context: NormalizeFontDataContext = {
     dev: nuxt.options.dev,
-    renderedFontURLs: new Map<string, string>(),
+    renderedFontURLs: new Map(),
     assetsBaseURL: options.prefix || '/_fonts',
     baseURL: nuxt.options.runtimeConfig.app.baseURL || nuxt.options.app.baseURL,
+    root: nuxt.options.rootDir,
   }
   nuxt.hook('modules:done', () => nuxt.callHook('fonts:public-asset-context', context))
 
   // Register font proxy URL for development
   async function devEventHandler(event: H3Event) {
     const filename = event.path.slice(1)
-    const url = context.renderedFontURLs.get(event.path.slice(1))
-    if (!url) {
+    const font = context.renderedFontURLs.get(event.path.slice(1))
+    if (!font) {
       throw createError({ statusCode: 404 })
     }
     const key = 'data:fonts:' + filename
     // Use storage to cache the font data between requests
     let res = await storage.getItemRaw<Buffer>(key)
     if (!res) {
-      res = await readFontData(url)
+      res = await readFontData(font)
       await storage.setItemRaw(key, res)
     }
     // Set immutable cache headers to prevent font flashes during development
@@ -122,7 +123,7 @@ export async function setupPublicAssetStrategy(storage: Storage<StorageValue>, o
       await fsp.rm(cacheDir, { recursive: true, force: true })
       await fsp.mkdir(cacheDir, { recursive: true })
       let banner = false
-      for (const [filename, url] of context.renderedFontURLs) {
+      for (const [filename, font] of context.renderedFontURLs) {
         const key = 'data:fonts:' + filename
         // Use storage to cache the font data between builds
         let res = await storage.getItemRaw<Buffer>(key)
@@ -131,9 +132,9 @@ export async function setupPublicAssetStrategy(storage: Storage<StorageValue>, o
             banner = true
             logger.info('Downloading fonts...')
           }
-          logger.log(colors.gray('  ├─ ' + url))
+          logger.log(colors.gray('  ├─ ' + font.url))
           try {
-            res = await readFontData(url)
+            res = await readFontData(font)
           }
           catch (error) {
             if (throwOnError) {
@@ -157,11 +158,11 @@ export async function setupPublicAssetStrategy(storage: Storage<StorageValue>, o
   }
 }
 
-async function readFontData(url: string) {
+async function readFontData({ url, init }: RenderedFont) {
   if (url.startsWith('file://')) {
     return await fsp.readFile(fileURLToPath(url))
   }
-  return await downloadFont(url)
+  return await downloadFont(url, { init })
 }
 
 const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365

--- a/src/download.ts
+++ b/src/download.ts
@@ -6,6 +6,8 @@ export interface DownloadFontOptions {
   retries?: number
   /** @default 500 */
   retryDelay?: number
+  /** `RequestInit` the font's provider requires, such as authorization headers. */
+  init?: RequestInit
 }
 
 /**
@@ -24,7 +26,7 @@ export async function downloadFont(url: string, options: DownloadFontOptions = {
 
   for (let attempt = 0; ; attempt++) {
     try {
-      return Buffer.from(await $fetch(url, { responseType: 'arrayBuffer', retry: false }))
+      return Buffer.from(await $fetch(url, { ...options.init, responseType: 'arrayBuffer', retry: false }))
     }
     catch (cause) {
       if (attempt >= retries) {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this updates us to the latest [fontless](https://github.com/unjs/fontaine/releases/tag/release-2026-08-23) + [unifont](https://github.com/unjs/unifont/releases), which includes a lot of bug fixes + new features, including unjs/fontaine#812 and unjs/fontaine#813 and unjs/unifont#464, unjs/unifont#465 and unjs/unifont#466, which I'll be opening PRs to use to resolve some existing bugs

one point to call out: emitted file names for local (`file:`) fonts now stay stable across machines rather than varying with the absolute path.

