### PR TITLE
test: cover tailwind v4 `--default-font-family` theme variables

### DIFF
--- a/docs/content/1.get-started/3.usage.md
+++ b/docs/content/1.get-started/3.usage.md
@@ -30,6 +30,18 @@ With Tailwind CSS you specify fonts using a CSS variable:
 }
 ```
 
+Overriding Tailwind's default font family works too, including via `@theme inline`, which compiles `--font-sans` down to `--default-font-family`:
+
+```css [main.css]
+@theme {
+  --default-font-family: "Inter", sans-serif;
+}
+```
+
+::note
+Nuxt Fonts reads the CSS Tailwind generates, so a font is only picked up if it ends up there. A `--font-*` theme variable that is never used by a utility (and is declared with `@theme inline`) is removed by Tailwind before Nuxt Fonts sees it. Use the utility at least once, declare it with `@theme static`, or set the font in `fonts.families` with `global: true`.
+::
+
 ::tip
 If you previously set `processCSSVariables` to `true` for Tailwind v4 support, it is no longer needed or recommended for v0.11.0 and above.
 ::

--- a/playgrounds/tailwindcss/app.vue
+++ b/playgrounds/tailwindcss/app.vue
@@ -6,6 +6,9 @@
   <div class="font-custom">
     Anton
   </div>
+  <div>
+    Rubik Storm (Tailwind default font family)
+  </div>
 </template>
 
 <style>
@@ -15,5 +18,6 @@
 
 @theme {
   --font-custom: "Anton", "sans-serif";
+  --default-font-family: "Rubik Storm", sans-serif;
 }
 </style>

--- a/test/css-frameworks/tailwind.test.ts
+++ b/test/css-frameworks/tailwind.test.ts
@@ -19,4 +19,9 @@ describe('tailwindcss features', () => {
       ]
     `)
   })
+
+  it('downloads fonts set via `--default-font-family`', async () => {
+    const html = await $fetch<string>('/')
+    expect(extractFontFaces('Rubik Storm', html).length).toBeGreaterThan(0)
+  })
 })

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -312,6 +312,29 @@ describe('filter patterns', () => {
     expect(result2).toContain('AnotherFont')
   })
 
+  it('should process Tailwind v4 `--default-font-family` with default `processCSSVariables`', async () => {
+    const plugin = FontFamilyInjectionPlugin({
+      dev: true,
+      processCSSVariables: 'font-prefixed-only',
+      selectFontsToPreload: (_family, fonts) => fonts,
+      fontsToPreload: new Map(),
+      resolveFontFace: family => ({
+        fonts: [{ src: [{ url: `/${slugify(family)}.woff2`, format: 'woff2' }] }],
+      }),
+    }).vite() as any
+
+    const css = `@layer theme { :root, :host { --default-font-family: "Rubik Storm", sans-serif; } }
+@layer base { :root, :host { font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif); } }`
+
+    const result = await plugin.transform?.handler?.(css, 'some-id.css').then((r: any) => r?.code)
+    expect(result).toContain('@font-face')
+    expect(result).toContain('Rubik Storm')
+
+    const mono = await plugin.transform?.handler?.(`:root { --default-mono-font-family: "Fira Mono", monospace; --other-var: "Kanit"; }`, 'some-id.css').then((r: any) => r?.code)
+    expect(mono).toContain(`font-family: 'Fira Mono'`)
+    expect(mono).not.toContain(`font-family: 'Kanit'`)
+  })
+
   it('should handle multiline CSS correctly', async () => {
     const transformWithoutCSSVariables = async (css: string) => {
       const plugin = FontFamilyInjectionPlugin({


### PR DESCRIPTION
### 🔗 Linked issue

closes #772
closes #638

### 📚 Description

overriding tailwind's default font previously meant the font was never downloaded:

```css
@theme { --default-font-family: "Rubik Storm", sans-serif; }
```

`@theme inline { --font-sans: … }` had the same problem, because tailwind compiles both down to a literal `--default-font-family` declaration, and our scanner only looked at `--font-*` variables.

this was fixed upstream in unjs/fontaine#812 by also treating `--*-font-family` custom properties as font-family usage. this adds a regression test, and documents that a font is only picked up if it survives into the CSS tailwind generates.