### PR TITLE
fix: pass dev font server errors to the next middleware

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -66,9 +66,14 @@ export async function setupPublicAssetStrategy(storage: Storage<StorageValue>, o
       if (server.config.appType !== 'custom' || nuxt.options.buildId === 'storybook') {
         server.middlewares.use(
           context.assetsBaseURL,
-          async (req, res) => {
-            const h3evt = createEvent(req, res)
-            res.end(await devEventHandler(h3evt))
+          async (req, res, next) => {
+            try {
+              const h3evt = createEvent(req, res)
+              res.end(await devEventHandler(h3evt))
+            }
+            catch (error) {
+              next(error)
+            }
           },
         )
       }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

the storybook/histoire dev middleware did `res.end(await devEventHandler(evt))`, so a 404 from the font handler rejected unhandled.

now, we pass it to `next(error)`.