### PR TITLE
fix: warn when deprecated `experimental.processCSSVariables` is set

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -66,9 +66,14 @@ export async function setupPublicAssetStrategy(storage: Storage<StorageValue>, o
       if (server.config.appType !== 'custom' || nuxt.options.buildId === 'storybook') {
         server.middlewares.use(
           context.assetsBaseURL,
-          async (req, res) => {
-            const h3evt = createEvent(req, res)
-            res.end(await devEventHandler(h3evt))
+          async (req, res, next) => {
+            try {
+              const h3evt = createEvent(req, res)
+              res.end(await devEventHandler(h3evt))
+            }
+            catch (error) {
+              next(error)
+            }
           },
         )
       }

--- a/src/module.ts
+++ b/src/module.ts
@@ -68,6 +68,10 @@ export default defineNuxtModule<ModuleOptions>({
     // Skip when preparing
     if (nuxt.options._prepare) return
 
+    if (options.experimental?.processCSSVariables !== undefined) {
+      logger.warn('`fonts.experimental.processCSSVariables` is deprecated. Use `fonts.processCSSVariables` instead.')
+    }
+
     if (!options.defaults?.fallbacks || !Array.isArray(options.defaults.fallbacks)) {
       const fallbacks = (options.defaults!.fallbacks as Exclude<NonNullable<typeof options.defaults>['fallbacks'], string[]>) ||= {}
       for (const _key in defaultValues.fallbacks) {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

`processCSSVariables` is no longer experimental (and for tailwind v4 users, no longer recommended at all). we still honour `experimental.processCSSVariables` but silently, so nobody finds out they're on the old option. this now warns.