### PR TITLE
refactor: let `fontless` fill per-category fallback defaults

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -66,9 +66,14 @@ export async function setupPublicAssetStrategy(storage: Storage<StorageValue>, o
       if (server.config.appType !== 'custom' || nuxt.options.buildId === 'storybook') {
         server.middlewares.use(
           context.assetsBaseURL,
-          async (req, res) => {
-            const h3evt = createEvent(req, res)
-            res.end(await devEventHandler(h3evt))
+          async (req, res, next) => {
+            try {
+              const h3evt = createEvent(req, res)
+              res.end(await devEventHandler(h3evt))
+            }
+            catch (error) {
+              next(error)
+            }
           },
         )
       }

--- a/src/module.ts
+++ b/src/module.ts
@@ -68,6 +68,10 @@ export default defineNuxtModule<ModuleOptions>({
     // Skip when preparing
     if (nuxt.options._prepare) return
 
+    if (options.experimental?.processCSSVariables !== undefined) {
+      logger.warn('`fonts.experimental.processCSSVariables` is deprecated. Use `fonts.processCSSVariables` instead.')
+    }
+
     if (!options.defaults?.fallbacks || !Array.isArray(options.defaults.fallbacks)) {
       const fallbacks = (options.defaults!.fallbacks as Exclude<NonNullable<typeof options.defaults>['fallbacks'], string[]>) ||= {}
       for (const _key in defaultValues.fallbacks) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -5,7 +5,7 @@ import { join, relative } from 'pathe'
 import { withoutLeadingSlash } from 'ufo'
 
 import defu from 'defu'
-import { createResolver, resolveProviders, defaultOptions, defaultValues, generateFontFace } from 'fontless'
+import { createResolver, resolveProviders, defaultOptions, generateFontFace } from 'fontless'
 import type { FontlessOptions, Resolver } from 'fontless'
 import type { FontFaceData } from 'unifont'
 import { createFontStorage } from './cache'
@@ -70,14 +70,6 @@ export default defineNuxtModule<ModuleOptions>({
 
     if (options.experimental?.processCSSVariables !== undefined) {
       logger.warn('`fonts.experimental.processCSSVariables` is deprecated. Use `fonts.processCSSVariables` instead.')
-    }
-
-    if (!options.defaults?.fallbacks || !Array.isArray(options.defaults.fallbacks)) {
-      const fallbacks = (options.defaults!.fallbacks as Exclude<NonNullable<typeof options.defaults>['fallbacks'], string[]>) ||= {}
-      for (const _key in defaultValues.fallbacks) {
-        const key = _key as keyof typeof fallbacks
-        fallbacks[key] ||= defaultValues.fallbacks[key]
-      }
     }
 
     const _providers = resolveProviders(options.providers, { root: nuxt.options.rootDir, alias: nuxt.options.alias })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

`fontless` now fills every generic family from its own defaults and prefers a provider-reported category, so we can drop our own code that did the same ...