### PR TITLE
feat(local): report filenames looked for when a family can't be resolved

### DIFF
--- a/src/providers/local.ts
+++ b/src/providers/local.ts
@@ -7,11 +7,12 @@ import { anyOf, createRegExp, not, wordBoundary } from 'magic-regexp'
 import { defineFontProvider } from 'unifont'
 import { withLeadingSlash, withTrailingSlash } from 'ufo'
 import { useNuxt } from '@nuxt/kit'
-import type { FontFaceData, ResolveFontResult } from 'unifont'
+import type { FontFaceData, FontProperties, FontStyles, ResolveFontResult } from 'unifont'
 
 import { parseFont } from 'fontless'
 import type { ModuleOptions } from '../types'
 import { logger } from '../logger'
+import { weightNames } from '../utils'
 import { resolvePackageDir } from './resolve'
 
 export interface LocalProviderOptions {
@@ -47,25 +48,50 @@ export default defineFontProvider('local', (options: LocalProviderOptions = {}) 
   const providerContext = {
     rootPaths: [] as string[],
     registry: {} as Record<string, string[]>,
+    /** What each registered file publishes, keyed by family slug and then by path. */
+    published: {} as Record<string, Map<string, PublishedProperties>>,
     emittedPaths: new Set<string>(),
   }
 
   const nuxt = useNuxt()
 
   function registerFont(path: string) {
-    const slugs = generateSlugs(path)
+    const { slugs, families, ...published } = parseFontFile(path)
     for (const slug of slugs) {
       providerContext.registry[slug] ||= []
       providerContext.registry[slug]!.push(path)
     }
+    for (const family of families) {
+      providerContext.published[family] ||= new Map()
+      providerContext.published[family]!.set(path, published)
+    }
   }
 
   function unregisterFont(path: string) {
-    const slugs = generateSlugs(path)
+    const { slugs, families } = parseFontFile(path)
     for (const slug of slugs) {
       providerContext.registry[slug] ||= []
       providerContext.registry[slug] = providerContext.registry[slug]!.filter(p => p !== path)
     }
+    for (const family of families) {
+      providerContext.published[family]?.delete(path)
+    }
+  }
+
+  function publishedProperties(fontFamily: string): FontProperties | undefined {
+    const published = providerContext.published[fontFamilyToSlug(fontFamily)]
+    if (!published || published.size === 0) {
+      return
+    }
+    const weights = new Set<string>()
+    const styles = new Set<FontStyles>()
+    const subsets = new Set<string>()
+    for (const { weight, style, subset } of published.values()) {
+      weights.add(weight)
+      styles.add(style)
+      subsets.add(subset)
+    }
+    return { weights: [...weights], styles: [...styles], subsets: [...subsets] }
   }
 
   function isExplicitlyLocal(fontFamily: string) {
@@ -153,6 +179,10 @@ export default defineFontProvider('local', (options: LocalProviderOptions = {}) 
   })
 
   return {
+    getFontProperties(fontFamily) {
+      return publishedProperties(fontFamily)
+    },
+
     resolveFont(fontFamily, options): ResolveFontResult | undefined {
       const fonts: FontFaceData[] = []
 
@@ -182,6 +212,7 @@ export default defineFontProvider('local', (options: LocalProviderOptions = {}) 
         const base = fontFamily.replace(/\s+/g, '-')
         const dirs = providerContext.rootPaths.map(root => relative(nuxt.options?.rootDir || '', root) || root)
         const list = (values: Array<string | number>) => values.map(value => `\`${value}\``).join(', ')
+        const published = publishedProperties(fontFamily)
         logger.warn([
           `Could not find a local font file for \`${fontFamily}\`.`,
           ` Looked for \`${base}[-<weight>][-<style>][-<subset>].[${extensionPriority.map(ext => ext.slice(1)).join('|')}]\``,
@@ -189,11 +220,18 @@ export default defineFontProvider('local', (options: LocalProviderOptions = {}) 
           `, where \`<weight>\` is one of ${list(options.weights)}`,
           `, \`<style>\` one of ${list(options.styles)}`,
           ` and \`<subset>\` one of ${list(options.subsets)}.`,
+          published
+            ? ` Font files were found for this family, publishing ${describe('weight', published.weights)}, ${describe('style', published.styles)} and ${describe('subset', published.subsets)}.`
+            : '',
         ].join(''))
       }
     },
   }
 })
+
+function describe(label: string, values: string[] = []) {
+  return `${label}${values.length === 1 ? '' : 's'} ${values.map(value => `\`${value}\``).join(', ')}`
+}
 
 const FONT_RE = /\.(?:ttf|woff|woff2|eot|otf)(?:\?[^.]+)?$/
 const NON_WORD_RE = /\W+/g
@@ -273,7 +311,21 @@ function variableWeightKeys(min: number, max: number) {
   return keys
 }
 
-function generateSlugs(path: string) {
+interface PublishedProperties {
+  /** A discrete weight (`'400'`) or a variable range (`'100 900'`). */
+  weight: string
+  style: FontStyles
+  subset: string
+}
+
+interface ParsedFontFile extends PublishedProperties {
+  /** Registry keys the file answers to. */
+  slugs: string[]
+  /** Family slugs the file could belong to. */
+  families: string[]
+}
+
+function parseFontFile(path: string): ParsedFontFile {
   let name = filename(path) || path
 
   const range = matchWeightRange(name)
@@ -287,18 +339,22 @@ function generateSlugs(path: string) {
     }
   }
 
+  const isVariable = VARIABLE_RE.test(name)
   const weightKeys = range
     ? variableWeightKeys(Number(range.groups!.min), Number(range.groups!.max))
-    : VARIABLE_RE.test(name)
+    : isVariable
       ? variableWeightKeys(100, 900)
       : [weightMap[weight!] || hyphenlessWeightMap[weight!.toLowerCase()] || weight!]
 
   const slugs = new Set<string>()
+  const families = new Set<string>()
 
   for (const slug of [name.replace(/\.\w*$/, ''), name.replace(/[._-]\w*$/, '')]) {
+    const family = fontFamilyToSlug(slug.replace(/[\W_]+$/, ''))
+    families.add(family)
     for (const weightKey of weightKeys) {
       slugs.add([
-        fontFamilyToSlug(slug.replace(/[\W_]+$/, '')),
+        family,
         weightKey,
         style,
         subset,
@@ -306,7 +362,28 @@ function generateSlugs(path: string) {
     }
   }
 
-  return [...slugs]
+  return {
+    slugs: [...slugs],
+    families: [...families],
+    weight: publishedWeight(range, isVariable, weight),
+    style: style.toLowerCase() as FontStyles,
+    subset: subset.toLowerCase(),
+  }
+}
+
+/**
+ * The weight a file publishes, as a discrete CSS weight or a variable range. A file whose name
+ * marks it as variable without bounding the range is assumed to cover every weight.
+ */
+function publishedWeight(range: RegExpMatchArray | undefined, isVariable: boolean, weight: string | undefined) {
+  if (range) {
+    return `${range.groups!.min} ${range.groups!.max}`
+  }
+  if (isVariable) {
+    return '100 900'
+  }
+  const name = (weight || 'normal').toLowerCase()
+  return String(weightNames[name] ?? name)
 }
 
 function fontFamilyToSlug(family: string) {

--- a/src/providers/local.ts
+++ b/src/providers/local.ts
@@ -10,6 +10,8 @@ import { useNuxt } from '@nuxt/kit'
 import type { FontFaceData, ResolveFontResult } from 'unifont'
 
 import { parseFont } from 'fontless'
+import type { ModuleOptions } from '../types'
+import { logger } from '../logger'
 import { resolvePackageDir } from './resolve'
 
 export interface LocalProviderOptions {
@@ -64,6 +66,15 @@ export default defineFontProvider('local', (options: LocalProviderOptions = {}) 
       providerContext.registry[slug] ||= []
       providerContext.registry[slug] = providerContext.registry[slug]!.filter(p => p !== path)
     }
+  }
+
+  function isExplicitlyLocal(fontFamily: string) {
+    const options = (nuxt.options as { fonts?: ModuleOptions } | undefined)?.fonts
+    if (!options) {
+      return false
+    }
+    const family = options.families?.find(family => family.name === fontFamily)
+    return (family && 'provider' in family ? family.provider : options.provider) === 'local'
   }
 
   const extensionPriority = ['.woff2', '.woff', '.ttf', '.otf', '.eot']
@@ -165,6 +176,20 @@ export default defineFontProvider('local', (options: LocalProviderOptions = {}) 
         return {
           fonts,
         }
+      }
+
+      if (isExplicitlyLocal(fontFamily)) {
+        const base = fontFamily.replace(/\s+/g, '-')
+        const dirs = providerContext.rootPaths.map(root => relative(nuxt.options?.rootDir || '', root) || root)
+        const list = (values: Array<string | number>) => values.map(value => `\`${value}\``).join(', ')
+        logger.warn([
+          `Could not find a local font file for \`${fontFamily}\`.`,
+          ` Looked for \`${base}[-<weight>][-<style>][-<subset>].[${extensionPriority.map(ext => ext.slice(1)).join('|')}]\``,
+          dirs.length > 0 ? ` within ${dirs.map(dir => `\`${dir}\``).join(', ')}` : '',
+          `, where \`<weight>\` is one of ${list(options.weights)}`,
+          `, \`<style>\` one of ${list(options.styles)}`,
+          ` and \`<subset>\` one of ${list(options.subsets)}.`,
+        ].join(''))
       }
     },
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,6 +12,37 @@ export function defineFontProvider(options: FontProvider) {
 
 export type { FontProvider } from './types'
 
+/**
+ * Named `font-weight` values accepted in `fonts.defaults.weights` and
+ * `fonts.families[].weights`, mapped to their numeric equivalent.
+ *
+ * Both the hyphenated (`semi-bold`) and unhyphenated (`semibold`, as used by
+ * Tailwind CSS) spellings are accepted.
+ */
+export const weightNames: Record<string, number> = {
+  'thin': 100,
+  'hairline': 100,
+  'extra-light': 200,
+  'extralight': 200,
+  'ultra-light': 200,
+  'ultralight': 200,
+  'light': 300,
+  'normal': 400,
+  'regular': 400,
+  'medium': 500,
+  'semi-bold': 600,
+  'semibold': 600,
+  'demi-bold': 600,
+  'demibold': 600,
+  'bold': 700,
+  'extra-bold': 800,
+  'extrabold': 800,
+  'ultra-bold': 800,
+  'ultrabold': 800,
+  'black': 900,
+  'heavy': 900,
+}
+
 // This needs to convert custom font providers to unifont-style providers
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function toUnifontProvider(name: string, provider: FontProvider): ProviderFactory<string, any, any> {

--- a/test/providers/local.test.ts
+++ b/test/providers/local.test.ts
@@ -14,6 +14,11 @@ vi.mock('@nuxt/kit', () => ({
   useNuxt: mockUseNuxt,
 }))
 
+const mockWarn = vi.hoisted(() => vi.fn())
+vi.mock('../../src/logger', () => ({
+  logger: { warn: mockWarn },
+}))
+
 describe('local font provider', () => {
   it('should scan for font files', async () => {
     const cleanup = await createFixture('scanning', [
@@ -334,6 +339,32 @@ describe('local font provider', () => {
       subsets: ['latin'],
       formats: ['woff2'],
     }).then(r => r.fonts)).toEqual([])
+
+    await cleanup()
+  })
+
+  it('should warn with the filenames it looked for when a local family cannot be resolved', async () => {
+    const cleanup = await createFixture('warn-missing', ['public/something-else.woff2'])
+    const provider = await setupFixture(['warn-missing/public'], {
+      rootDir: fixturePath,
+      fonts: { provider: 'local' },
+    })
+    mockWarn.mockClear()
+
+    expect(await provider.resolveFont('Faro Variable', {
+      weights: ['400'],
+      styles: ['normal'],
+      subsets: ['latin'],
+      formats: ['woff2'],
+    }).then(r => r.fonts)).toEqual([])
+
+    expect(mockWarn.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "Could not find a local font file for \`Faro Variable\`. Looked for \`Faro-Variable[-<weight>][-<style>][-<subset>].[woff2|woff|ttf|otf|eot]\` within \`warn-missing/public\`, where \`<weight>\` is one of \`400\`, \`<style>\` one of \`normal\` and \`<subset>\` one of \`latin\`.",
+        ],
+      ]
+    `)
 
     await cleanup()
   })

--- a/test/providers/local.test.ts
+++ b/test/providers/local.test.ts
@@ -369,6 +369,57 @@ describe('local font provider', () => {
     await cleanup()
   })
 
+  it('should report the weights, styles and subsets it found for a family', async () => {
+    const cleanup = await createFixture('properties', [
+      'public/MyFont-bold.woff2',
+      'public/MyFont-bold-italic.woff2',
+      'public/MyFont-100-900.woff2',
+      'public/MyFont-normal-cyrillic.woff2',
+    ])
+    const provider = await setupFixture(['properties/public'])
+
+    const properties = await provider.getFontProperties('MyFont')
+    expect(properties?.provider).toBe('local')
+    expect(properties?.weights?.sort()).toEqual(['100 900', '400', '700'])
+    expect(properties?.styles?.sort()).toEqual(['italic', 'normal'])
+    expect(properties?.subsets?.sort()).toEqual(['cyrillic', 'latin'])
+    expect(await provider.getFontProperties('Unknown Font')).toBeUndefined()
+
+    await cleanup()
+  })
+
+  it('should normalise the casing of published metadata', async () => {
+    const cleanup = await createFixture('metadata-casing', ['public/MyFont-Bold-Italic-Cyrillic.woff2'])
+    const provider = await setupFixture(['metadata-casing/public'])
+
+    expect(await provider.getFontProperties?.('MyFont')).toMatchObject({
+      styles: ['italic'],
+      subsets: ['cyrillic'],
+    })
+
+    await cleanup()
+  })
+
+  it('should report what a family publishes when the requested weight cannot be found', async () => {
+    const cleanup = await createFixture('warn-available', ['public/MyFont-bold.woff2'])
+    const provider = await setupFixture(['warn-available/public'], {
+      rootDir: fixturePath,
+      fonts: { provider: 'local' },
+    })
+    mockWarn.mockClear()
+
+    expect(await provider.resolveFont('MyFont', {
+      weights: ['300'],
+      styles: ['normal'],
+      subsets: ['latin'],
+      formats: ['woff2'],
+    }).then(r => r.fonts)).toEqual([])
+
+    expect(mockWarn.mock.calls[0]![0]).toContain('Font files were found for this family, publishing weight `700`, style `normal` and subset `latin`.')
+
+    await cleanup()
+  })
+
   it('should scan additional directories, including within `node_modules`', async () => {
     const cleanup = await createFixture('npm-package', [
       'node_modules/geist/dist/fonts/Geist-Bold.woff2',


### PR DESCRIPTION
### 🔗 Linked issue

closes #791

### 📚 Description

at the moment failures resolving fonts from local fonts don't give you much to act on:

```
WARN  Could not produce font face declaration from local for font family Faro Variable.
```

now, when the `local` provider is explicitly the one being asked, it now says what it looked for:

> Could not find a local font file for `MyFont`. Looked for `MyFont[-<weight>][-<style>].[woff2|woff|ttf|otf|eot]` within `public`, where `<weight>` is one of `300`. Font files were found for this family, publishing weight `700`, style `normal` and subset `latin`.

> [!NOTE]
> this is only logged or families that asked for `local` (by family or by `fonts.provider`), so it doesn't fire for families that merely fall through `local` on the way to google.